### PR TITLE
SPV / Lite-Blocks Support

### DIFF
--- a/lib/saito/block.ts
+++ b/lib/saito/block.ts
@@ -132,7 +132,6 @@ class Block {
    * @returns {Block}
    */
   deserialize(buffer?) {
-
     const transactions_length = this.app.binary.u32FromBytes(
       buffer.slice(0, 4)
     );
@@ -1038,8 +1037,20 @@ class Block {
   generateTransactionsHashmap() {
     if (!this.txs_hmap_generated) {
       for (let i = 0; i < this.transactions.length; i++) {
-        for (let ii = 0; ii < this.transactions[i].transaction.from.length; ii++) { this.txs_hmap[this.transactions[i].transaction.from[ii].add] = 1; }
-        for (let ii = 0; ii < this.transactions[i].transaction.to.length; ii++) { this.txs_hmap[this.transactions[i].transaction.to[ii].add] = 1; }
+        for (
+          let ii = 0;
+          ii < this.transactions[i].transaction.from.length;
+          ii++
+        ) {
+          this.txs_hmap[this.transactions[i].transaction.from[ii].add] = 1;
+        }
+        for (
+          let ii = 0;
+          ii < this.transactions[i].transaction.to.length;
+          ii++
+        ) {
+          this.txs_hmap[this.transactions[i].transaction.to[ii].add] = 1;
+        }
       }
       this.txs_hmap_generated = true;
     }
@@ -1058,9 +1069,13 @@ class Block {
   }
 
   hasKeylistTransactions(keylist) {
-    if (!this.txs_hmap_generated) { this.generateTransactionsHashmap(); }
+    if (!this.txs_hmap_generated) {
+      this.generateTransactionsHashmap();
+    }
     for (let i = 0; i < keylist.length; i++) {
-      if (this.txs_hmap[keylist[i]] == 1) { return true; }
+      if (this.txs_hmap[keylist[i]] == 1) {
+        return true;
+      }
     }
     return false;
   }
@@ -1232,15 +1247,13 @@ class Block {
   //
   // returns a lite-version of the block
   //
-  returnLiteBlock(keylist=[]): any {
-
+  returnLiteBlock(keylist = []): any {
     let pruned_transactions = [];
 
     //
     // generate lite-txs
     //
     for (let i = 0; i < this.transactions.length; i++) {
-
       let add_this_tx = 0;
       for (let k = 0; k < keylist.length; k++) {
         if (this.transactions[i].hasPublicKey(keylist[k])) {
@@ -1252,30 +1265,30 @@ class Block {
       if (add_this_tx == 1) {
         pruned_transactions.push(this.transactions[i]);
       } else {
-
         let spv = new Transaction();
-            spv.transaction.type = 9;
-            spv.transaction.r    = 1;
-	    // the sig contains the hash of this TX
-            spv.transaction.sig  = this.app.crypto.hash(this.transactions[i].serializeForSignature(this.app).toString("hex"));
+        spv.transaction.type = 9;
+        spv.transaction.r = 1;
+        // the sig contains the hash of this TX
+        spv.transaction.sig = this.app.crypto.hash(
+          this.transactions[i].serializeForSignature(this.app).toString("hex")
+        );
 
-            //delete spv.transaction.to;
-            //delete spv.transaction.from;
-            //delete spv.transaction.m;
-            //delete spv.transaction.ts;
-            //delete spv.transaction.path;
+        //delete spv.transaction.to;
+        //delete spv.transaction.from;
+        //delete spv.transaction.m;
+        //delete spv.transaction.ts;
+        //delete spv.transaction.path;
 
-            delete spv.fees_total;
-            delete spv.work_available_to_me;
-            delete spv.work_available_to_creator;
-            delete spv.work_cumulative;
-            delete spv.msg;
-            delete spv.dmsg;
-            delete spv.size;
-            delete spv.is_valid;
-            delete spv.path;
+        delete spv.fees_total;
+        delete spv.work_available_to_me;
+        delete spv.work_available_to_creator;
+        delete spv.work_cumulative;
+        delete spv.msg;
+        delete spv.dmsg;
+        delete spv.size;
+        delete spv.is_valid;
+        delete spv.path;
         pruned_transactions.push(spv);
-
       }
     }
 
@@ -1283,7 +1296,7 @@ class Block {
     // prune unnecessary txs into merkle-tree
     //
     let no_simplification_needed = 0;
-/*****
+    /*****
     while (no_simplification_needed == 0) {
       let action_taken = 0;
       for (let i = 1; i < pruned_transactions.length; i++) {
@@ -1303,14 +1316,11 @@ class Block {
 ****/
 
     let newblk = new Block(this.app);
-        newblk.block = Object.assign({}, this.block);
-        newblk.transactions = pruned_transactions;
+    newblk.block = Object.assign({}, this.block);
+    newblk.transactions = pruned_transactions;
 
     return newblk;
-
   }
-
-
 
   returnPreviousBlockHash() {
     return this.block.previous_block_hash;

--- a/lib/saito/block.ts
+++ b/lib/saito/block.ts
@@ -1266,15 +1266,15 @@ class Block {
             //delete spv.transaction.ts;
             //delete spv.transaction.path;
 
-            //delete spv.fees_total;
-            //delete spv.work_available_to_me;
-            //delete spv.work_available_to_creator;
-            //delete spv.work_cumulative;
-            //delete spv.msg;
-            //delete spv.dmsg;
-            //delete spv.size;
-            //delete spv.is_valid;
-            //delete spv.path;
+            delete spv.fees_total;
+            delete spv.work_available_to_me;
+            delete spv.work_available_to_creator;
+            delete spv.work_cumulative;
+            delete spv.msg;
+            delete spv.dmsg;
+            delete spv.size;
+            delete spv.is_valid;
+            delete spv.path;
         pruned_transactions.push(spv);
 
       }

--- a/lib/saito/block.ts
+++ b/lib/saito/block.ts
@@ -193,7 +193,6 @@ class Block {
       this.block.signature = "";
     }
 
-    console.debug("transaction count = " + transactions_length);
     for (let i = 0; i < transactions_length; i++) {
       const inputs_len = this.app.binary.u32FromBytes(
         buffer.slice(start_of_transaction_data, start_of_transaction_data + 4)
@@ -1306,8 +1305,6 @@ class Block {
     let newblk = new Block(this.app);
         newblk.block = Object.assign({}, this.block);
         newblk.transactions = pruned_transactions;
-
-console.log("PRUNED TXS LENGTH: " + newblk.transactions.length);
 
     return newblk;
 

--- a/lib/saito/blockchain.ts
+++ b/lib/saito/blockchain.ts
@@ -3,6 +3,7 @@ import * as JSON from "json-bigint";
 import { Saito } from "../../apps/core";
 import Blockring from "./blockring";
 import Staking from "./staking";
+import Transaction, { TransactionType } from "./transaction";
 
 class Blockchain {
   public app: Saito;

--- a/lib/saito/blockring.ts
+++ b/lib/saito/blockring.ts
@@ -41,7 +41,6 @@ class Blockring {
 
   containsBlockHashAtBlockId(block_id, block_hash) {
     const insert_pos = block_id % this.ring_buffer_length;
-    console.debug("block hashes", this.ring[insert_pos].block_hashes);
     return this.ring[insert_pos].block_hashes.includes(block_hash);
   }
 

--- a/lib/saito/core/server.ts
+++ b/lib/saito/core/server.ts
@@ -258,6 +258,8 @@ console.log("Here we are!");
 	pkey = req.params.pkey;
       }
 
+console.log("PKEY IS: " + pkey);
+
       const bsh = req.params.bhash;
       let keylist = [];
       let peer = null;
@@ -276,9 +278,13 @@ console.log("Here we are2!");
         keylist.push(pkey);
       } else {
         keylist = peer.peer.keylist;
+        if (!keylist.includes(pkey)) {
+	  keylist.push(pkey);
+	}
       }
 
 console.log("lite-block");
+console.log("keylist: " + JSON.stringify(keylist));
 
       //
       // SHORTCUT hasKeylistTransactions returns (1 for yes, 0 for no, -1 for unknown)

--- a/lib/saito/core/server.ts
+++ b/lib/saito/core/server.ts
@@ -3,7 +3,6 @@ import { Saito } from "../../../apps/core";
 import express from "express";
 import { Server as Ser } from "http";
 
-
 // const io          = require('socket.io')(webserver, {
 //   cors: {
 //     origin: "*.*",
@@ -14,7 +13,7 @@ import fs from "fs";
 import path from "path";
 import bodyParser from "body-parser";
 
-const JSON = require('json-bigint');
+const JSON = require("json-bigint");
 const app = express();
 const webserver = new Ser(app);
 
@@ -79,7 +78,6 @@ class Server {
   }
 
   initialize() {
-
     const server_self = this;
 
     if (this.app.BROWSER === 1) {
@@ -214,18 +212,20 @@ class Server {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         let blk = server_self.app.blockchain.blocks[bhash];
-        if (!blk) { return; }
+        if (!blk) {
+          return;
+        }
         let blkwtx = new Block(server_self.app);
-	blkwtx.block = JSON.parse(JSON.stringify(blk.block));
-	blkwtx.transactions = blk.transactions;
+        blkwtx.block = JSON.parse(JSON.stringify(blk.block));
+        blkwtx.transactions = blk.transactions;
         blkwtx.app = null;
 
-          res.writeHead(200, {
-            "Content-Type": "text/plain",
-            "Content-Transfer-Encoding": "utf8",
-          });
-          res.write(Buffer.from(JSON.stringify(blkwtx), 'utf8'), 'utf8');
-          res.end();
+        res.writeHead(200, {
+          "Content-Type": "text/plain",
+          "Content-Transfer-Encoding": "utf8",
+        });
+        res.write(Buffer.from(JSON.stringify(blkwtx), "utf8"), "utf8");
+        res.end();
       } catch (err) {
         //
         // file does not exist on disk, check in memory
@@ -246,14 +246,13 @@ class Server {
     // lite-blocks //
     /////////////////
     app.get("/lite-block/:bhash/:pkey", async (req, res) => {
-
       if (req.params.bhash == null) {
         return;
       }
 
       let pkey = server_self.app.wallet.returnPublicKey();
       if (req.params.pkey != null) {
-	pkey = req.params.pkey;
+        pkey = req.params.pkey;
       }
 
       const bsh = req.params.bhash;
@@ -264,8 +263,8 @@ class Server {
       // @ts-ignore
       for (let i = 0; i < this.app.network.peers.length; i++) {
         if (this.app.network.peers[i].returnPublicKey() === pkey) {
-	  peer = this.app.network.peers[i];
-	}
+          peer = this.app.network.peers[i];
+        }
       }
 
       if (peer == null) {
@@ -273,8 +272,8 @@ class Server {
       } else {
         keylist = peer.peer.keylist;
         if (!keylist.includes(pkey)) {
-	  keylist.push(pkey);
-	}
+          keylist.push(pkey);
+        }
       }
 
       //
@@ -290,7 +289,6 @@ class Server {
       // @ts-ignore
       let block = this.app.blockchain.blocks[bsh];
       if (block) {
-
         if (block.hasKeylistTransactions(bsh, keylist) === 0) {
           res.writeHead(200, {
             "Content-Type": "text/plain",
@@ -298,8 +296,10 @@ class Server {
           });
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
-	  let liteblock = block.returnLiteBlock(keylist);
-          let buffer = Buffer.from(liteblock.serialize(), "binary").toString("base64");
+          let liteblock = block.returnLiteBlock(keylist);
+          let buffer = Buffer.from(liteblock.serialize(), "binary").toString(
+            "base64"
+          );
 
           //res.write(Buffer.from(liteblock.serialize(), "utf8"), "utf8");
           res.write(buffer, "utf8");
@@ -325,8 +325,10 @@ class Server {
             "Content-Transfer-Encoding": "utf8",
           });
 
-  	  let liteblock = block.returnLiteBlock(keylist);
-          let buffer = Buffer.from(liteblock.serialize(), "binary").toString("base64");
+          let liteblock = block.returnLiteBlock(keylist);
+          let buffer = Buffer.from(liteblock.serialize(), "binary").toString(
+            "base64"
+          );
           res.write(buffer, "utf8");
           //res.write(Buffer.from(liteblock.serialize(), "utf8"), "utf8");
           res.end();
@@ -335,7 +337,6 @@ class Server {
         return;
       }
     });
-
 
     app.get("/block/:hash", async (req, res) => {
       const hash = req.params.hash;

--- a/lib/saito/core/server.ts
+++ b/lib/saito/core/server.ts
@@ -247,8 +247,6 @@ class Server {
     /////////////////
     app.get("/lite-block/:bhash/:pkey", async (req, res) => {
 
-console.log("Here we are!");
-
       if (req.params.bhash == null) {
         return;
       }
@@ -258,13 +256,9 @@ console.log("Here we are!");
 	pkey = req.params.pkey;
       }
 
-console.log("PKEY IS: " + pkey);
-
       const bsh = req.params.bhash;
       let keylist = [];
       let peer = null;
-
-console.log("Here we are2!");
 
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
@@ -283,9 +277,6 @@ console.log("Here we are2!");
 	}
       }
 
-console.log("lite-block");
-console.log("keylist: " + JSON.stringify(keylist));
-
       //
       // SHORTCUT hasKeylistTransactions returns (1 for yes, 0 for no, -1 for unknown)
       // if we have this block but there are no transactions for it in the block hashmap
@@ -299,8 +290,6 @@ console.log("keylist: " + JSON.stringify(keylist));
       // @ts-ignore
       let block = this.app.blockchain.blocks[bsh];
       if (block) {
-
-console.log("block exists");
 
         if (block.hasKeylistTransactions(bsh, keylist) === 0) {
           res.writeHead(200, {
@@ -326,7 +315,6 @@ console.log("block exists");
         let blk = await this.app.storage.loadBlockByHash(bsh);
 
         if (blk == null) {
-console.log("SENDING AN EMPTY BLOCK AS NOT LOADED!");
           res.send("{}");
           return;
         } else {
@@ -355,7 +343,6 @@ console.log("SENDING AN EMPTY BLOCK AS NOT LOADED!");
         console.warn("hash not provided");
         return res.sendStatus(400); // Bad request
       }
-      console.log("requesting block : " + hash);
 
       const block = await this.app.blockchain.loadBlockAsync(hash);
       if (!block) {

--- a/lib/saito/core/storage-core.ts
+++ b/lib/saito/core/storage-core.ts
@@ -235,8 +235,6 @@ class StorageCore extends Storage {
 
   async loadBlockByFilename(filename) {
 
-    console.log("trying to load: " + filename);
-
     try {
       if (fs.existsSync(filename)) {
         const data = fs.readFileSync(filename);

--- a/lib/saito/core/storage-core.ts
+++ b/lib/saito/core/storage-core.ts
@@ -236,7 +236,6 @@ class StorageCore extends Storage {
   }
 
   async loadBlockByFilename(filename) {
-
     try {
       if (fs.existsSync(filename)) {
         const data = fs.readFileSync(filename);
@@ -246,9 +245,7 @@ class StorageCore extends Storage {
         block.generateHashes();
         return block;
       } else {
-        console.error(
-          `cannot open: ${filename} as it does not exist on disk`
-        );
+        console.error(`cannot open: ${filename} as it does not exist on disk`);
         return null;
       }
     } catch (err) {

--- a/lib/saito/core/storage-core.ts
+++ b/lib/saito/core/storage-core.ts
@@ -1,15 +1,10 @@
 "use strict";
 
 import saito from "../saito";
-
 import Storage from "../storage";
-
 import fs from "fs-extra";
-
 import * as JSON from "json-bigint";
-
 import path from "path";
-
 import sqlite from "sqlite";
 import { Saito } from "../../../apps/core";
 import Block from "../block";
@@ -79,11 +74,11 @@ class StorageCore extends Storage {
     return filename;
   }
 
-  loadBlockFromDisk(filename) {
+  async loadBlockFromDisk(filename) {
     try {
       if (fs.existsSync(filename)) {
         const buffer = fs.readFileSync(filename);
-        const block = new saito.block(this.app);
+        const block = new Block(this.app);
         block.deserialize(buffer);
         block.generateMetadata();
         return block;
@@ -156,7 +151,7 @@ class StorageCore extends Storage {
   /**
    * Saves a block to database and disk and shashmap
    *
-   * @param {saito.block} block block
+   * @param {Block} block block
    */
   async saveBlock(block: Block): Promise<string> {
     try {
@@ -239,14 +234,13 @@ class StorageCore extends Storage {
   }
 
   async loadBlockByFilename(filename) {
-    const block_filename = `${this.data_dir}/${this.dest}/${filename}`;
 
-    console.log("trying to load: " + block_filename);
+    console.log("trying to load: " + filename);
 
     try {
-      if (fs.existsSync(block_filename)) {
-        const data = fs.readFileSync(block_filename);
-        const block = new saito.block(this.app);
+      if (fs.existsSync(filename)) {
+        const data = fs.readFileSync(filename);
+        const block = new Block(this.app);
 
         block.deserialize(data);
         block.generateMetadata();
@@ -255,7 +249,7 @@ class StorageCore extends Storage {
         return block;
       } else {
         console.error(
-          `cannot open: ${block_filename} as it does not exist on disk`
+          `cannot open: ${filename} as it does not exist on disk`
         );
         return null;
       }

--- a/lib/saito/network.ts
+++ b/lib/saito/network.ts
@@ -223,7 +223,9 @@ class Network {
     try {
       let url = `${peer.peer.protocol}://${peer.peer.host}:${peer.peer.port}/block/${block_hash}`;
       if (this.app.BROWSER == 1 || this.app.SPVMODE == 1) {
-        url = `${peer.peer.protocol}://${peer.peer.host}:${peer.peer.port}/lite-block/${block_hash}/${this.app.wallet.returnPublicKey()}`;
+        url = `${peer.peer.protocol}://${peer.peer.host}:${
+          peer.peer.port
+        }/lite-block/${block_hash}/${this.app.wallet.returnPublicKey()}`;
       }
       console.log("URL: " + url);
       const res = await fetch(url);

--- a/lib/saito/network.ts
+++ b/lib/saito/network.ts
@@ -228,19 +228,14 @@ class Network {
       }
       console.log("URL: " + url);
       const res = await fetch(url);
-console.log("downloaded!");
       if (res.ok) {
         const base64Buffer = await res.arrayBuffer();
         const buffer = Buffer.from(
           Buffer.from(base64Buffer).toString("utf-8"),
           "base64"
         );
-console.log("about to create block!");
         const block = new saito.block(this.app);
-console.log("1: " + JSON.stringify(block.block));
-console.log("buffer as hex: " + buffer.toString('hex'));
         block.deserialize(buffer);
-console.log("2: " + JSON.stringify(block.block));
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         block.peer = this;

--- a/lib/saito/network.ts
+++ b/lib/saito/network.ts
@@ -222,17 +222,25 @@ class Network {
     }
 
     try {
-      const url = `${peer.peer.protocol}://${peer.peer.host}:${peer.peer.port}/block/${block_hash}`;
+      let url = `${peer.peer.protocol}://${peer.peer.host}:${peer.peer.port}/block/${block_hash}`;
+      if (this.app.BROWSER == 1 || this.app.SPVMODE == 1) {
+        url = `${peer.peer.protocol}://${peer.peer.host}:${peer.peer.port}/lite-block/${block_hash}/${this.app.wallet.returnPublicKey()}`;
+      }
       console.log("URL: " + url);
       const res = await fetch(url);
+console.log("downloaded!");
       if (res.ok) {
         const base64Buffer = await res.arrayBuffer();
         const buffer = Buffer.from(
           Buffer.from(base64Buffer).toString("utf-8"),
           "base64"
         );
+console.log("about to create block!");
         const block = new saito.block(this.app);
+console.log("1: " + JSON.stringify(block.block));
+console.log("buffer as hex: " + buffer.toString('hex'));
         block.deserialize(buffer);
+console.log("2: " + JSON.stringify(block.block));
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         block.peer = this;

--- a/lib/saito/saito.ts
+++ b/lib/saito/saito.ts
@@ -48,7 +48,6 @@ import transaction0 from "./transaction";
 
 import wallet0 from "./wallet";
 
-
 export default class SaitoCommon {
   static binary = binary0;
   static block = block0;

--- a/lib/saito/storage.ts
+++ b/lib/saito/storage.ts
@@ -159,11 +159,11 @@ class Storage {
    **/
   deleteBlockFromDisk(filename) {}
 
-  loadBlockById(bid) {}
+  async loadBlockById(bid): Promise<Block> { return null; }
 
-  loadBlockByHash(bsh) {}
+  async loadBlockByHash(bsh): Promise<Block> { return null; }
 
-  loadBlockFromDisk(filename) {}
+  async loadBlockFromDisk(filename): Promise<Block> { return null; }
 
   async loadBlockByFilename(filename): Promise<Block> {
     return null;

--- a/lib/saito/storage.ts
+++ b/lib/saito/storage.ts
@@ -159,11 +159,17 @@ class Storage {
    **/
   deleteBlockFromDisk(filename) {}
 
-  async loadBlockById(bid): Promise<Block> { return null; }
+  async loadBlockById(bid): Promise<Block> {
+    return null;
+  }
 
-  async loadBlockByHash(bsh): Promise<Block> { return null; }
+  async loadBlockByHash(bsh): Promise<Block> {
+    return null;
+  }
 
-  async loadBlockFromDisk(filename): Promise<Block> { return null; }
+  async loadBlockFromDisk(filename): Promise<Block> {
+    return null;
+  }
 
   async loadBlockByFilename(filename): Promise<Block> {
     return null;

--- a/lib/saito/transaction.ts
+++ b/lib/saito/transaction.ts
@@ -42,7 +42,6 @@ class Transaction {
   public size: number;
   public is_valid: any;
   public path: Hop[];
-  public returnTotalFees: any;
 
   constructor(jsonobj = null) {
     /////////////////////////
@@ -534,7 +533,7 @@ class Transaction {
     // of routing work that it is possible for this transaction
     // to contain (2x the fee).
     //
-    let aggregate_routing_work = this.returnTotalFees();
+    let aggregate_routing_work = this.returnFeesTotal();
     let routing_work_this_hop = aggregate_routing_work;
     const work_by_hop = [];
     work_by_hop.push(aggregate_routing_work);
@@ -914,6 +913,12 @@ class Transaction {
 
   generateMetadataCumulativeWork() {
     return BigInt(0);
+  }
+
+  hasPublicKey(publickey) {
+    let slips = this.returnSlipsToAndFrom(publickey);
+    if (slips.to.length > 0 || slips.from.length > 0) { return true; }
+    return false;
   }
 
   /* stolen from app crypto to avoid including app */

--- a/lib/saito/transaction.ts
+++ b/lib/saito/transaction.ts
@@ -917,7 +917,9 @@ class Transaction {
 
   hasPublicKey(publickey) {
     let slips = this.returnSlipsToAndFrom(publickey);
-    if (slips.to.length > 0 || slips.from.length > 0) { return true; }
+    if (slips.to.length > 0 || slips.from.length > 0) {
+      return true;
+    }
     return false;
   }
 

--- a/mods/arcade/arcade.js
+++ b/mods/arcade/arcade.js
@@ -8,8 +8,7 @@ const getMockGames = require('./mockinvites.js');
 const ArcadeContainerTemplate = require('./lib/arcade-main/templates/arcade-container.template');
 const ModalRegisterEmail = require('../../lib/saito/ui/modal-register-email/modal-register-email');
 const JSON = require('json-bigint');
-
-fetch = require("node-fetch");
+const fetch = require("node-fetch");
 
 class Arcade extends ModTemplate {
 
@@ -531,7 +530,6 @@ try {
                 if (transaction.options.players_needed <= (transaction.players.length + 1)) {
                   console.info("ACCEPT MESSAGE SENT ON GAME WAITING FOR ONE PLAYER! -- deleting");
                   this.games.splice(i, 1);
-                  console.info("RE-RENDER");
                   this.renderArcadeMain(this.app, this);
                 }
               }

--- a/mods/relay/relay.js
+++ b/mods/relay/relay.js
@@ -1,5 +1,5 @@
-var saito = require('../../lib/saito/saito');
 var ModTemplate = require('../../lib/templates/modtemplate');
+var saito = require('../../lib/saito/saito');
 const JSON = require('json-bigint');
 
 


### PR DESCRIPTION
This PR adds lite-block / spv support back into the JS client.

Nodes that have app.BROWSER or app.SPVMODE set positively will now fetchBlocks from the server using a different lite-block URL that feeds out lite-blocks rather than full blocks. These lite-blocks are not yet optimized and all transactions are currently sent (in compact form) rather than only the subset that are not stripped from the merkle-tree, but this still provides a significant gain in block compactness.

Supporting SPV clients requires the server to support this new API format, and will require JS browsers to connect to a JS server until the Rust client is updated to support this format as well. The new blocks produced will only include transactions in the keylist for that peer, or for the publickey of the peer if there is no local keylist.

Among significant changes, the block serialization / deserialization functions have been updated to include a 4-byte variable (r=replaces) that is used in generating / calculating the merkle root of blocks that do not contain full transaction data.  We will need to update the block serialization/deserialization in the Rust client shortly. Servers are responsible for setting this variable appropriately when generating lite-blocks.

Pushing this PR live as it speeds up the process of downloading blocks for lite-clients and is a step towards getting the live Arcade updated to the new testnet, as lite-client support is important for application responsiveness on the test network.

