### PR TITLE
feat: initial income cap

### DIFF
--- a/lib/saito/block.ts
+++ b/lib/saito/block.ts
@@ -3,7 +3,7 @@ import Slip, { SlipType } from "./slip";
 import Transaction, { HOP_SIZE, SLIP_SIZE, TRANSACTION_SIZE, TransactionType } from "./transaction";
 import { Saito } from "../../apps/core";
 
-const BLOCK_HEADER_SIZE = 213;
+const BLOCK_HEADER_SIZE = 229;
 
 export enum BlockType {
   Ghost = 0,
@@ -25,6 +25,8 @@ class Block {
     treasury: BigInt(0),
     staking_treasury: BigInt(0),
     signature: "",
+    avg_income: BigInt(0),
+    avg_variance: BigInt(0),
   };
   public lc: number;
   public force: any;
@@ -149,6 +151,11 @@ class Block {
     this.block.difficulty = parseInt(
       this.app.binary.u64FromBytes(buffer.slice(205, 213)).toString()
     );
+
+    this.block.avg_income = BigInt(this.app.binary.u64FromBytes(buffer.slice(213, 221)));
+    this.block.avg_variance = BigInt(this.app.binary.u64FromBytes(buffer.slice(221, 229)));
+
+
     let start_of_transaction_data = BLOCK_HEADER_SIZE;
 
     //
@@ -292,6 +299,7 @@ class Block {
   }
 
   async generateConsensusValues() {
+
     //
     // this is also set in blockchain.js
     //
@@ -303,7 +311,6 @@ class Block {
     const cv: any = {};
 
     cv.total_fees = BigInt(0);
-
     cv.ft_num = 0;
     cv.gt_num = 0;
     cv.it_num = 0;
@@ -320,6 +327,8 @@ class Block {
     cv.rebroadcasts = [];
     cv.block_payouts = [];
     cv.fee_transaction = null;
+    cv.avg_income = BigInt(0);
+    cv.avg_variance = BigInt(0);
 
     //
     // total fees and indices
@@ -353,10 +362,14 @@ class Block {
     }
 
     //
-    // difficulty
+    // difficulty and fee averages
     //
     const previous_block = await this.app.blockchain.loadBlockAsync(this.block.previous_block_hash);
     if (previous_block) {
+
+      //
+      // difficulty depends on previous block
+      //
       const difficulty = previous_block.returnDifficulty();
 
       if (previous_block.hasGoldenTicket() && cv.gt_num === 0) {
@@ -368,11 +381,34 @@ class Block {
       } else {
         cv.expected_difficulty = difficulty;
       }
+
+      //
+      // average income and variance depends on previous block too
+      //
+      cv.avg_income = previous_block.block.avg_income;
+      cv.avg_variance = previous_block.block.avg_variance;
+
+      if (previous_block.block.avg_income > cv.total_fees) {
+	let adjustment = (previous_block.block.avg_income - cv.total_fees) / this.app.blockchain.blockchain.genesis_period;
+        if (adjustment > 0) { cv.avg_income -= adjustment; }
+      }
+      if (previous_block.block.avg_income > cv.total_fees) {
+	let adjustment = (previous_block.block.avg_income + cv.total_fees) / this.app.blockchain.blockchain.genesis_period;
+        if (adjustment > 0) { cv.avg_income += adjustment; }
+      }
+
     } else {
       //
       // if there is no previous block, the difficulty is not adjusted. validation
       // rules will cause the block to fail unless it is the first block.
       //
+
+      //
+      // set average income and variance so non-failure on first block
+      // doesn't result in failure calculating avg_income and avg_variance
+      //
+      cv.avg_income = this.block.avg_income;
+      cv.avg_variance = this.block.avg_variance;
     }
 
     //
@@ -460,11 +496,23 @@ class Block {
       const miner_publickey = gt.creator;
 
       //
+      // limit previous block payout to avg income
+      //
+      let previous_block_payout = previous_block.returnFeesTotal();
+      if (
+	previous_block_payout > (previous_block.block.avg_income * 1.25) &&
+	previous_block_payout > 50
+      ) {
+	previous_block_payout = previous_block.block.avg_income * 1.24;
+      }
+
+
+      //
       // miner payout is fees from previous block, no staking treasury
       //
       if (previous_block) {
-        const miner_payment = previous_block.returnFeesTotal() / BigInt(2);
-        const router_payment = previous_block.returnFeesTotal() / BigInt(2);
+        const miner_payment = previous_block_payout / BigInt(2);
+        const router_payment = previous_block_payout / BigInt(2);
 
         //
         // calculate miner and router payments
@@ -544,8 +592,20 @@ class Block {
                 // be withheld for the staker treasury, which is what previous_staker_
                 // payment is measuring.
                 //
-                const sp = staking_block.returnFeesTotal() / BigInt(2);
-                const rp = staking_block.returnFeesTotal() - sp;
+
+	        //
+	        // limit previous block payout to avg income
+	        //
+	        let previous_staking_block_payout = staking_block.returnFeesTotal();
+	        if (
+	  	  previous_staking_block_payout > (staking_block.block.avg_income * 1.25) &&
+		  previous_staking_block_payout > 50
+      	        ) {
+	  	  previous_staking_block_payout = staking_block.block.avg_income * 1.24;
+      		}
+
+                const sp = previous_staking_block_payout / BigInt(2);
+                const rp = previous_staking_block_payout - sp;
 
                 const block_payout = {
                   miner: "",
@@ -766,6 +826,13 @@ class Block {
     // contextual values
     //
     const cv = await this.generateConsensusValues();
+
+    //
+    // average income and income variance
+    //
+    this.block.avg_income = cv.avg_income;
+    this.block.avg_variance = cv.avg_variance;
+
 
     //
     // ATR transactions - TODO, make more efficient?
@@ -1309,6 +1376,9 @@ class Block {
     const burnfee = this.app.binary.u64AsBytes(this.block.burnfee.toString());
     const difficulty = this.app.binary.u64AsBytes(this.block.difficulty);
 
+    const avg_income = this.app.binary.u64AsBytes(this.block.avg_income.toString());
+    const avg_variance = this.app.binary.u64AsBytes(this.block.avg_variance.toString());
+
     const block_header_data = new Uint8Array([
       ...transactions_length,
       ...id,
@@ -1321,6 +1391,8 @@ class Block {
       ...staking_treasury,
       ...burnfee,
       ...difficulty,
+      ...avg_income,
+      ...avg_variance,
     ]);
 
     if (block_type === BlockType.Header) {
@@ -1362,6 +1434,8 @@ class Block {
       this.app.binary.u64AsBytes(this.block.staking_treasury.toString()),
       this.app.binary.u64AsBytes(this.block.burnfee.toString()),
       this.app.binary.u64AsBytes(this.block.difficulty),
+      this.app.binary.u64AsBytes(this.block.avg_income),
+      this.app.binary.u64AsBytes(this.block.avg_variance),
     ]);
   }
 
@@ -1423,6 +1497,20 @@ class Block {
     // generate consensus values
     //
     const cv = await this.generateConsensusValues();
+
+    //
+    // average income and average income variance
+    //
+    if (cv.avg_income !== this.block.avg_income) {
+      console.log("ERROR 712923: block is mis-reporting its average income");
+      return false;
+    }
+    if (cv.avg_variance !== this.block.avg_variance) {
+      console.log("ERROR 712923: block is mis-reporting its average variance");
+      return false;
+    }
+
+
 
     //
     // only block #1 can have an issuance transaction


### PR DESCRIPTION
This adds income cap / smoothing to payouts under Saito Consensus. The technique restricts the maximum payout that any block will issue to 125% of a smoothed average of the most recent period of blocks.

Attackers doubling the fees that flow into the blockchain in order to subsidize their own attacks on the chain are thus forced to take a loss as it becomes impossible to break even. This feature is not set to affect payouts until the TX FEE flow hits 50 SAITO per block, in order to avoid variance which will be natural at low fee volume.

We presumably will want to systematize and modify this technique in the future.