### PR TITLE
Daniel/settlers

### DIFF
--- a/lib/saito/ui/game-board-sizer/game-board-sizer.js
+++ b/lib/saito/ui/game-board-sizer/game-board-sizer.js
@@ -50,6 +50,10 @@ class GameBoardSizer {
       //Requery screen size
         let boardWidth = parseInt(window.getComputedStyle(targetObject).width);
         let boardHeight = parseInt(window.getComputedStyle(targetObject).height);
+        if (window.getComputedStyle(targetObject).boxSizing == "content-box"){
+          boardWidth += parseInt(window.getComputedStyle(targetObject).paddingLeft) + parseInt(window.getComputedStyle(targetObject).paddingRight);
+          boardHeight += parseInt(window.getComputedStyle(targetObject).paddingTop) + parseInt(window.getComputedStyle(targetObject).paddingBottom);
+        }
         let screenRatio = Math.min(window.innerWidth / boardWidth, window.innerHeight / boardHeight);
 
         console.log("***INIT BOARD SIZING***","board width:"+boardWidth,"board height: "+boardHeight, screenRatio);
@@ -73,7 +77,8 @@ class GameBoardSizer {
           }else{
             offset = Math.round((window.innerHeight - targetObject.getBoundingClientRect().height)/2) + 5;
           }
-         targetObject.style.top = offset+"px";    
+          offset = Math.max(0, offset-parseInt(window.getComputedStyle(targetObject).paddingTop));
+          targetObject.style.top = offset+"px";    
         }
     }
    

--- a/lib/saito/ui/game-cardfan/game-cardfan.js
+++ b/lib/saito/ui/game-cardfan/game-cardfan.js
@@ -38,7 +38,7 @@ class GameCardfan {
           .join("");
       }
       if (!cards_html) {
-        console.error("Card Fan can't find player hand");
+        console.log("Error? Card Fan can't find player hand");
       }
 
       document.getElementById("cardfan").innerHTML = cards_html;

--- a/mods/settlers/settlers.js
+++ b/mods/settlers/settlers.js
@@ -542,6 +542,7 @@ class Settlers extends GameTemplate {
       if (mv[0] == "init") {
         //this.game.queue.splice(qe, 1);   // no splice, we want to bounce off this
         this.game.state.placedCity = null; //We are in game play mode, not initial set up
+        $(".diceroll").css("display","flex");
         for (let i = this.game.players.length; i > 0; i--) {
           //count backwards so it goes P1, P2, P3,
           this.game.queue.push(`play\t${i}`);
@@ -1211,6 +1212,12 @@ class Settlers extends GameTemplate {
 
         this.game.state.playerTurn = player;
         this.playerbox.insertGraphic("diceroll",player);
+        this.playerbox.addClass('flash');
+        setTimeout(() => {
+              $(".flash").removeClass("flash");
+            }, 3000);
+      
+
 
         if (this.game.player == player) {
           /*

--- a/mods/settlers/settlers.js
+++ b/mods/settlers/settlers.js
@@ -13,8 +13,8 @@ class Settlers extends GameTemplate {
     this.app = app;
 
     this.name = "Settlers";
-    this.gamename = "Settlers of Saito";
-    this.description = `Island colonization and settlement game. Collect resources and build your way to dominance.`;
+    this.gamename = "Settlers of Saitoa";
+    this.description = `Explore the island of Saitoa, collect resources, and build your way to dominance.`;
     this.categories = "Games Arcade Entertainment";
     this.type = "Strategy Boardgame";
     this.status = "Beta";
@@ -120,6 +120,21 @@ class Settlers extends GameTemplate {
 
     return html;
   }
+
+  returnWelcomeOverlay(){
+    let html = `<div class="rules-overlay trade_overlay">
+                <h1>Welcome to the Island of Saitoa</h1>
+                <h2>Initial Placement Phase</h2>
+                <p>Every one gets to start by placing two ${this.skin.c1.name}s anywhere on the board, each with an attached ${this.skin.r.name}. ${this.skin.c1.name}s go on the corners of the hexagon tiles, while ${this.skin.r.name}s go on the edges. When the dice roll the number of that tile, adjacent ${this.skin.c1.name}s produce that resource.</p>
+                <p>In order to be fair, the players take turns making their initial placement first in last out, i.e. the first player to place their first ${this.skin.c1.name} is the last player to place their second ${this.skin.c1.name}. You begin the game with the resources adjacent to your second ${this.skin.c1.name}.</p>
+                <h2>Good Luck!</h2>
+                <p>For more detailed instructions of the game, see "RULES" under the game menu. For detailed instructions on trading, refer to the "HELP" item under the trade menu.</p>
+                <div class="button close_welcome_overlay" id="close_welcome_overlay">Start Playing</div>
+                </div>
+  `;
+    return html;
+  }
+
 
   /*
   Make Overlay of game introduction/Rules
@@ -506,6 +521,7 @@ class Settlers extends GameTemplate {
     state.ports = [];
     state.lastroll = [];
     state.placedCity = "hello world"; //a slight hack for game iniitalization
+    state.welcome = 0;
     for (let i = 0; i < this.game.players.length; i++) {
       state.players.push({});
       state.players[i].resources = [];
@@ -548,15 +564,17 @@ class Settlers extends GameTemplate {
       /* Game Setup */
 
       if (mv[0] == "init") {
-        this.game.queue.splice(qe, 1);   // no splice, we want to bounce off this
+        this.game.queue.splice(qe, 1);   
         this.game.state.placedCity = null; //We are in game play mode, not initial set up
-        $(".diceroll").css("display");
+        this.game.state.lastroll = [0,0];
+        this.displayDice();
+        $(".diceroll").css("display","");
         this.game.queue.push("round");
         this.displayModal("Now we begin game play");
         return 1;
       }
 
-      if (mv[0] == "round"){
+      if (mv[0] == "round"){ // no splice, we want to bounce off this
         for (let i = this.game.players.length; i > 0; i--) {
           //count backwards so it goes P1, P2, P3,
           this.game.queue.push(`play\t${i}`);
@@ -767,6 +785,16 @@ class Settlers extends GameTemplate {
         let player = parseInt(mv[1]);
         this.game.queue.splice(qe, 1);
         this.stopTrading();
+
+        //For the beginning of the game only...
+        if (this.game.state.welcome == 0 && this.browser_active) {
+            this.overlay.show(this.app, this, this.returnWelcomeOverlay());
+            document.querySelector(".close_welcome_overlay").onclick = (e) => {
+              this.overlay.hide();
+            };
+          this.game.state.welcome = 1;
+        }
+
         if (this.game.player == player) {
           this.playerBuildCity(mv[1]);
         } else {

--- a/mods/settlers/web/style.css
+++ b/mods/settlers/web/style.css
@@ -166,7 +166,6 @@ body {
 
 /* Dice */
 .diceroll{
-  display: none;
   width: min(12vw,120px);
   margin: 0 auto;
   /*position: absolute;
@@ -177,7 +176,7 @@ body {
   border-radius: 5px;
   background-color: #222B;
   padding: min(0.5vw,5px);
-  display: none; /*flex;*/
+  display: flex;
   flex-direction: row;
   justify-content: space-evenly;
   z-index: 3;
@@ -891,7 +890,7 @@ ul.horizontal_list li.iconoption{
 .flash {
   animation-name: flash;
   animation-duration: .8s;
-  animation-iteration-count: 2;
+  animation-iteration-count: 3;
   animation-fill-mode: backwards;
 }
 

--- a/mods/settlers/web/style.css
+++ b/mods/settlers/web/style.css
@@ -177,7 +177,7 @@ body {
   border-radius: 5px;
   background-color: #222B;
   padding: min(0.5vw,5px);
-  display: flex;
+  display: none; /*flex;*/
   flex-direction: row;
   justify-content: space-evenly;
   z-index: 3;
@@ -433,6 +433,7 @@ body {
 
 .player-box.me{
   border-top: 10px solid;
+  border-right: 10px solid;
 }
 .player-box.notme{
   border-left: 10px solid;
@@ -884,6 +885,25 @@ ul.horizontal_list li.iconoption{
 
 .stats-table .icon{
   width: 50px;
+}
+
+
+.flash {
+  animation-name: flash;
+  animation-duration: .8s;
+  animation-iteration-count: 2;
+  animation-fill-mode: backwards;
+}
+
+@keyframes flash {
+  0% {
+    opacity: .8;
+    background-color: white;
+    color: black !important;
+  }
+  100% {
+    opacity: 1;
+  }
 }
 
 

--- a/mods/settlers/web/style.css
+++ b/mods/settlers/web/style.css
@@ -164,34 +164,7 @@ body {
   box-shadow: unset;
 }
 
-/* Dice */
-.diceroll{
-  width: min(12vw,120px);
-  margin: 0 auto;
-  /*position: absolute;
-  /*top: 0px;
-  left: 50%;
-  transform: translateX(-5vw);*/
-  border: 2px solid black;
-  border-radius: 5px;
-  background-color: #222B;
-  padding: min(0.5vw,5px);
-  display: flex;
-  flex-direction: row;
-  justify-content: space-evenly;
-  z-index: 3;
-}
 
-.die{
-  width: min(4vw,40px);
-}
-.hud-body {
-  overflow: unset;
-}
-
-.textchoice {
-  
-}
 
 .status-message ul li:hover, .status ul li:hover, .cardselector:hover{
   color: black;
@@ -543,6 +516,10 @@ body {
   /*overflow-y: scroll;*/
 }
 
+.rules-overlay{
+  overflow-y: scroll;
+}
+
 .trade_overlay_title{
   width: 100%;
   text-align: center;
@@ -675,7 +652,7 @@ ul.horizontal_list li.iconoption{
 .me > .player-box-graphic{
   position: absolute;
   /*left: calc(150px + 8vw);*/
-  bottom: calc(100% + 10px);
+  bottom: calc(100% + 12px);
   left: 50%;
   transform: translateX(-50%);
 }
@@ -683,12 +660,42 @@ ul.horizontal_list li.iconoption{
 .notme > .player-box-graphic{
   position: absolute;
   top: 50%;
-  right: calc(100% + 10px);
+  right: calc(100% + 12px);
   transform: translateY(-50%);
   /*position: relative;
   z-index: -1;
   top: 5vh;
   left: 1vw;*/
+}
+
+
+/* Dice */
+.diceroll{
+  width: min(12vw,110px);
+  margin: 0 auto;
+  /*position: absolute;
+  /*top: 0px;
+  left: 50%;
+  transform: translateX(-5vw);*/
+  border: 2px solid black;
+  border-radius: 5px;
+  background-color: #222B;
+  padding: min(0.5vw,5px) 0;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-evenly;
+  z-index: 3;
+}
+
+.die{
+  width: min(4vw,40px);
+}
+
+.notme .diceroll{
+  width: 50px;
+  height: min(12vw, 110px);
+  padding: 0 min(0.5vw,5px);
+  flex-direction: column;
 }
 
 .flexline{
@@ -922,13 +929,20 @@ ul.horizontal_list li.iconoption{
   }
  
   .notme > .player-box-graphic{
-    top: unset;
     right: unset;
     position: absolute;
-    bottom: calc(100% + 5px);
+    top: calc(100% + 5px);
     left: 50%;
     transform: translateX(-50%);
 }   
+
+  .notme .diceroll{
+    width: min(12vw, 110px);
+    height: 50px;
+    padding: min(0.5vw,5px) 0 ;
+    flex-direction: row;
+}
+
 }
 
 /*Still need better layout for small screens*/


### PR DESCRIPTION
-- Fixes #386 

Addresses some of the items in #382 and in google sheet, including:
 -- changed messaging for placing villages in initial setup
 -- hide dice in initial set up
 -- uses an alert to explain why your trade overlay closes 
 
Other changes:
-- Playerbox flashes three times when it is your turn (h/t Victor)
-- Added a brief introductory welcome overlay to orient new users
-- Added an alert to inform players of transition between initial set up and proper game play
-- Fixed the default/autosizing of the gameboard ** (how did no one tag this as a problem?)
-- doubling down on the naming of the island as "Saitoa" since people keep flagging that as a typo. 
