### PR TITLE
Daniel/settlers

### DIFF
--- a/lib/saito/ui/game-board-sizer/game-board-sizer.js
+++ b/lib/saito/ui/game-board-sizer/game-board-sizer.js
@@ -50,6 +50,10 @@ class GameBoardSizer {
       //Requery screen size
         let boardWidth = parseInt(window.getComputedStyle(targetObject).width);
         let boardHeight = parseInt(window.getComputedStyle(targetObject).height);
+        if (window.getComputedStyle(targetObject).boxSizing == "content-box"){
+          boardWidth += parseInt(window.getComputedStyle(targetObject).paddingLeft) + parseInt(window.getComputedStyle(targetObject).paddingRight);
+          boardHeight += parseInt(window.getComputedStyle(targetObject).paddingTop) + parseInt(window.getComputedStyle(targetObject).paddingBottom);
+        }
         let screenRatio = Math.min(window.innerWidth / boardWidth, window.innerHeight / boardHeight);
 
         console.log("***INIT BOARD SIZING***","board width:"+boardWidth,"board height: "+boardHeight, screenRatio);
@@ -73,7 +77,8 @@ class GameBoardSizer {
           }else{
             offset = Math.round((window.innerHeight - targetObject.getBoundingClientRect().height)/2) + 5;
           }
-         targetObject.style.top = offset+"px";    
+          offset = Math.max(0, offset-parseInt(window.getComputedStyle(targetObject).paddingTop));
+          targetObject.style.top = offset+"px";    
         }
     }
    

--- a/lib/saito/ui/game-cardfan/game-cardfan.js
+++ b/lib/saito/ui/game-cardfan/game-cardfan.js
@@ -38,7 +38,7 @@ class GameCardfan {
           .join("");
       }
       if (!cards_html) {
-        console.error("Card Fan can't find player hand");
+        console.log("Error? Card Fan can't find player hand");
       }
 
       document.getElementById("cardfan").innerHTML = cards_html;

--- a/lib/saito/ui/game-cardfan/game-cardfan.js
+++ b/lib/saito/ui/game-cardfan/game-cardfan.js
@@ -80,9 +80,24 @@ class GameCardfan {
    */
   addClass(classname) {
     try {
-      document.getElementById("cardfan").classList.add(classname);
+      if (!document.getElementById("cardfan").classList.contains(classname)){
+        document.getElementById("cardfan").classList.add(classname);  
+      }
     } catch (err) {}
   }
+
+  /**
+   * Removes a class name for the cardFan to facilitate customization of display
+   * @param classname {string} - the class name
+   */
+  removeClass(classname) {
+    try {
+      if (document.getElementById("cardfan").classList.contains(classname)){
+        document.getElementById("cardfan").classList.remove(classname);  
+      }
+    } catch (err) {}
+  }
+
 
   /**
    * Inserts the html for a single card into the start of the fan (left side)

--- a/mods/settlers/lib/settlers.skin.js
+++ b/mods/settlers/lib/settlers.skin.js
@@ -56,11 +56,11 @@ class SettlersSkin {
 				this.b = {name: "bandit"};
 				this.s = {name: "knight", img:`<i class="fas fa-horse-head"></i>`};
 				this.t = {name: "bank"};
-				this.vp = {name: "VP", svg:`<svg viewbox="0 0 200 200"><circle fill="gold" cx="100" cy="100" r="95" stroke="goldenrod" stroke-width="5"/> <text x="50%" y="50%" text-anchor="middle" dominant-baseline="middle" font-size="132px" fill="saddlebrown">1</text></svg>`};
+				this.vp = {name: "VP", svg:`<svg viewbox="0 0 200 200"><circle fill="gold" cx="100" cy="100" r="95" stroke="goldenrod" stroke-width="5"/> <text x="50%" y="60%" text-anchor="middle" dominant-baseline="middle" font-size="132px" fill="saddlebrown">1</text></svg>`};
 				this.longest = {name: "Longest Road",svg:`<svg viewbox="0 0 200 200"><circle fill="gold" cx="100" cy="100" r="95" stroke="goldenrod" stroke-width="5"/>
-		      						<text x="50%" y="50%" text-anchor="middle" dominant-baseline="middle" font-size="132px" fill="saddlebrown">2</text></svg><i class="fas fa-road" style="color:goldenrod;"></i>`};
+		      						<text x="50%" y="60%" text-anchor="middle" dominant-baseline="middle" font-size="132px" fill="saddlebrown">2</text></svg><i class="fas fa-road" style="color:goldenrod;"></i>`};
 				this.largest = {name:"Largest Army",svg:`<svg viewbox="0 0 200 200"><circle fill="gold" cx="100" cy="100" r="95" stroke="gold" stroke-width="5"/>
-		      <text x="50%" y="50%" text-anchor="middle" dominant-baseline="middle" font-size="132px" fill="saddlebrown">2</text></svg><i class="fas fa-horse-head" style="color:gold;"></i>`};
+		      <text x="50%" y="60%" text-anchor="middle" dominant-baseline="middle" font-size="132px" fill="saddlebrown">2</text></svg><i class="fas fa-horse-head" style="color:gold;"></i>`};
 				this.resources = [{name: "brick",count:3,ict:3,icon:"/settlers/img/icons/brick-icon.png"},
 								  {name: "wood",count:4,ict:3,icon:"/settlers/img/icons/wood-icon.png"},
 								  {name: "wheat",count:4,ict:3,icon:"/settlers/img/icons/wheat-icon.png"},

--- a/mods/settlers/settlers.js
+++ b/mods/settlers/settlers.js
@@ -27,6 +27,7 @@ class Settlers extends GameTemplate {
     this.maxPlayers = 4;
 
     this.tradeWindowOpen = false;
+    this.is_sleeping = true;
   }
   //
   // requestInterface(type) {
@@ -272,7 +273,6 @@ class Settlers extends GameTemplate {
       callback: function (app, game_mod) {
         game_mod.menu.hideSubMenus();
         if (game_mod.game.state.canTrade && game_mod.game.player ===  game_mod.game.state.playerTurn) {
-            game_mod.tradeWindowOpen = true;
             game_mod.showTradeOverlay();
         }else{
           salert("You cannot trade right now");
@@ -448,6 +448,7 @@ class Settlers extends GameTemplate {
     let html = `<div class="rules-overlay">
                 <h1>Game Statistics</h1>`;
 
+    //Fucking Dice
     html += `<table class="stats-table"><caption>Dice Rolls</caption><thead><tr><th>Rolls: </th>`;
     for (let i = 2; i <= 12; i++){
       html += `<th>${i}</th>`;
@@ -458,6 +459,7 @@ class Settlers extends GameTemplate {
     }
     html += `</tr></tbody></table>`;
    
+    //Production Log
     html += `<table class="stats-table"><caption>Resources Produced</caption><thead><tr><th></th>`;
     for (let r in this.game.stats.production){
       html += `<th>${this.returnResourceHTML(r)}</th>`; 
@@ -484,7 +486,54 @@ class Settlers extends GameTemplate {
     html += `</tr>`;
     html += `</tbody></table>`;
     
-    return html;
+    //VP Race
+    html += `<table class="stats-table"><caption>VP Race</caption><thead><tr><th></th>`;
+    html += `<th><div class="tip token p${this.game.player}">${this.skin.c1.svg}<div class="tiptext">${this.skin.c1.name}</div></div></th>`;
+    html += `<th><div class="tip token p${this.game.player}">${this.skin.c2.svg}<div class="tiptext">${this.skin.c2.name}</div></div></th>`;
+    html += `<th><div class="tip token">${this.skin.vp.svg}<div class="tiptext">${this.skin.vp.name}</div></div></th>`;
+    html += `<th><div class="tip token">${this.skin.largest.svg}<div class="tiptext">${this.skin.largest.name}</div></div></th>`;
+    html += `<th><div class="tip token">${this.skin.longest.svg}<div class="tiptext">${this.skin.longest.name}</div></div></th>`;
+    html += `<th>Total</th></tr></thead><tbody>`;
+    //Sort players by VP
+    let ranking_scores = [this.game.state.players[0].vp];
+    let ranking_players = [0];
+    for (let i = 1; i < this.game.state.players.length; i++){
+      let j = 0;
+      for (; j < ranking_scores.length; j++){
+        if (this.game.state.players[i].vp > ranking_scores[j]){
+          break; 
+        }
+      }
+      ranking_scores.splice(j,0,this.game.state.players[i].vp);
+      ranking_players.splice(j,0,i);
+    }
+    for (let i = 0; i < ranking_scores.length; i++){
+      let player = ranking_players[i];
+      let numVil = 0;
+      let numCity = 0;
+      for (let j = 0; j < this.game.state.cities.length; j++) {
+        if (this.game.state.cities[j].player === player + 1) {
+          if (this.game.state.cities[j].level == 1){
+            numVil++;
+          }else{
+            numCity++;
+          }
+        }
+      }
+
+      html += `<tr><th>Player ${player + 1}</th>
+                <td>${numVil}</td>
+                <td>${numCity}</td>
+                <td>${this.game.state.players[player].vpc}</td>
+                <td>${(this.game.state.largestArmy.player == player + 1)?this.game.state.largestArmy.size:""}</td>
+                <td>${(this.game.state.longestRoad.player == player + 1)?this.game.state.longestRoad.size:""}</td>
+                <td>${ranking_scores[i]}</td></tr>`;
+    }
+    
+
+    html += `</tbody></table>`;
+
+    return html+"</div>";
   }
 
   /*
@@ -514,7 +563,7 @@ class Settlers extends GameTemplate {
     state.hexes = {};
     state.roads = [];
     state.cities = [];
-    state.longestRoad = { length: 0, player: 0 };
+    state.longestRoad = { size: 0, player: 0 };
     state.largestArmy = { size: 0, player: 0 };
     state.players = [];
     state.playerTurn = 0;
@@ -607,6 +656,7 @@ class Settlers extends GameTemplate {
           );
         }
         this.overlay.show(this.app, this, this.returnStatsOverlay());
+        $(".rules-overlay h1").text(`Game Over: Player ${winner} wins!`);
         this.game.winner = this.game.players[winner - 1];
         this.resignGame(this.game.id); //? post to leaderboard - ignore 'resign'
         return 0;
@@ -706,16 +756,17 @@ class Settlers extends GameTemplate {
         //Collect all instances of the resource
         for (let i = 0; i < this.game.state.players.length; i++) {
           if (player != i + 1) {
-            for (
-              let j = 0;
-              j < this.game.state.players[i].resources.length;
-              j++
-            ) {
+            let am_i_a_victim = false;
+            for (let j = 0; j < this.game.state.players[i].resources.length; j++) {
               if (this.game.state.players[i].resources[j] == resource) {
+                am_i_a_victim = true;
                 lootCt++;
                 this.game.state.players[i].resources.splice(j, 1);
                 j--;
               }
+            }
+            if (am_i_a_victim && this.game.player == i+1){
+              this.displayModal(cardname,`Player ${player} stole all your ${resource}`);
             }
           }
         }
@@ -955,7 +1006,6 @@ class Settlers extends GameTemplate {
             this.showTradeOffer(offering_player, stuff_in_return, stuff_on_offer);
           } else {
             //Within the playerbox to evaluate a trade offer
-            salert("New trade offer");
             //Check if I can accept the trade
             let can_accept = true;
             for (let r in stuff_in_return){
@@ -964,20 +1014,26 @@ class Settlers extends GameTemplate {
               }
             }
 
-            //Simplify resource objects
-            let offer = this.wishListToString(stuff_on_offer);
-            let ask = this.wishListToString(stuff_in_return);
-
-            let html = `<div class="pbtrade">Offers <span class="highlight">${offer}</span> in exchange for <span class="highlight">${ask}</span>`;
-            html += "<ul>";
             if (can_accept){
-              html += '<li class="pboption" id="accept">accept</li>';
-              html += '<li class="pboption" id="reject">reject</li>';  
-            }else{
-              html += '<div class="pboption">You cannot meet the trade</div>';
-              html += '<li class="pboption" id="reject">okay</li>';  
+              this.displayModal("New trade offer");
             }
-            html += "</ul>";
+
+            //Simplify resource objects
+            let offer = this.wishListToImage(stuff_on_offer) || "<em>nothing</em>";
+            let ask = this.wishListToImage(stuff_in_return) || "<em>nothing</em>";
+
+            let html = `<div class="pbtrade">
+                          <div>Offers <span class="tip highlight">${offer}</span> for <span class="tip highlight">${ask}</span></div>`;
+            
+            if (can_accept){
+              html += `<ul>
+                        <li class="pboption" id="accept">accept</li>
+                        <li class="pboption" id="reject">reject</li>
+                      </ul>`;  
+            }else{
+              html += `<div class="pboption">You cannot meet the trade</div>
+                       <ul><li class="pboption" id="reject">okay</li></ul>`;  
+            }
             html += "</div>";
 
             this.playerbox.refreshLog(html, offering_player);
@@ -1257,7 +1313,6 @@ class Settlers extends GameTemplate {
         this.game.state.playerTurn = player;
         this.playerbox.insertGraphic("diceroll",player);
 
-
         if (this.game.player == player) {
 
           /*
@@ -1280,11 +1335,13 @@ class Settlers extends GameTemplate {
           this.updateStatus(html);
 
           //Flash to be like "hey it's your move"
-          this.playerbox.addClass('flash');
-          setTimeout(() => {
-              $(".flash").removeClass("flash");
-            }, 3000);
-
+          if (this.is_sleeping){
+            this.playerbox.addClass('flash');
+            setTimeout(() => {
+                $(".flash").removeClass("flash");
+              }, 3000);
+              this.is_sleeping = false;  
+          }
 
           //roll the dice by clicking on the dice
           if (document.querySelector("#diceroll")) {
@@ -1309,7 +1366,6 @@ class Settlers extends GameTemplate {
               settlers_self.endTurn();
             }
             if (choice === "knight") {
-              //settlers_self.addMove(`play\t${player}\tSTOP`); //Still have to roll
               settlers_self.playerPlayCard();
             }
           });
@@ -1528,7 +1584,6 @@ class Settlers extends GameTemplate {
             this.updateStatus(oldhtml + html);
             $("#tradenow").on("click", function () {
               settlers_self.showTradeOverlay(player);
-              //settlers_self.privateTrade(player);
             });
           } else {
             this.updateStatus(
@@ -1546,7 +1601,7 @@ class Settlers extends GameTemplate {
         this.game.state.canPlayCard = this.game.deck[0].hand.length > 0;
         this.stopTrading();
         this.game.queue.splice(qe - 1, 2);
-
+        this.is_sleeping = true;
         // remove city highlighting from last roll
         for (let city of this.game.state.cities) {
           document.querySelector(`#${city.slot}`).classList.remove("producer");
@@ -2059,6 +2114,7 @@ class Settlers extends GameTemplate {
   */
   displayCardfan(deck = "") {
     try {
+      let usingDev = false;
       let cards = "";
       if (deck == "resource" || deck == "") {
         for (let r of this.game.state.players[this.game.player - 1].resources) {
@@ -2071,6 +2127,7 @@ class Settlers extends GameTemplate {
       }
       if (deck == "cards" || cards == "") {
         //Dev Cards
+        usingDev = true;
         for (let x = 0; x < this.game.deck[0].hand.length; x++) {
           let card = this.game.deck[0].cards[this.game.deck[0].hand[x]];
           cards += `<div class="card tip"><img src="${card.img}">
@@ -2082,7 +2139,13 @@ class Settlers extends GameTemplate {
       }
       if (cards){
         this.cardfan.render(this.app, this, cards);
-        this.cardfan.addClass("bighand");
+        if (usingDev){
+          this.cardfan.addClass("staggered-hand");
+          this.cardfan.removeClass("bighand");
+        }else{
+          this.cardfan.addClass("bighand");  
+          this.cardfan.removeClass("staggered-hand");
+        }
         this.cardfan.attachEvents(this.app, this);  
       }
     } catch (err) {
@@ -2540,10 +2603,6 @@ class Settlers extends GameTemplate {
         settlers_self.bankTrade();
         return;
       }
-      /*if (id === "trade") {
-        settlers_self.playerTrade();
-        return;
-      }*/
       if (id === "playcard") {
         settlers_self.playerPlayCard();
         return;
@@ -2725,7 +2784,7 @@ class Settlers extends GameTemplate {
 
     html += `<li class="option" id="cancel">go back</li>`;
     html += "</ul></div>";
-    this.updateStatus(html, 1);
+    this.updateStatus(html, 0);  
 
     $(".option").off();
     $(".option").on("click", function () {
@@ -2884,7 +2943,7 @@ class Settlers extends GameTemplate {
     }
     return false;
   }
-
+    
 
   /*
     Recursively let player select two resources, then push them to game queue to share selection
@@ -2901,11 +2960,11 @@ class Settlers extends GameTemplate {
     let gainResource = function (settlers_self) {
       let html = `<div class='tbd'>Select Resources (Can get ${remaining}): <ul class="horizontal_list">`;
       for (let i of resourceList) {
-        html += `<li id="${i}" class="option">${settlers_self.returnResourceHTML(i)}</li>`;
+        html += `<li id="${i}" class="iconoption option">${settlers_self.returnResourceHTML(i)}</li>`;
       }
       html += "</ul>";
       html += "</div>";
-
+      settlers_self.displayCardfan();
       settlers_self.updateStatus(html, 1);
 
       $(".option").off();
@@ -2941,13 +3000,13 @@ class Settlers extends GameTemplate {
     //Player recursively selects all the resources they want to get rid of
     let html = `<div class='tbd'>Select Desired Resource: <ul class="horizontal_list">`;
     for (let i of resourceList) {
-      html += `<li id="${i}" class="option">${settlers_self.returnResourceHTML(i)}</li>`;
+      html += `<li id="${i}" class="iconoption option">${settlers_self.returnResourceHTML(i)}</li>`;
     }
     html += "</ul>";
     html += "</div>";
 
     settlers_self.updateStatus(html, 1);
-
+    settlers_self.displayCardfan();
     $(".option").off();
     $(".option").on("click", function () {
       let res = $(this).attr("id");
@@ -3144,7 +3203,8 @@ class Settlers extends GameTemplate {
     this.game.state.canTrade = false; //Once you spend resources, you can no longer trade
     if (this.tradeWindowOpen){
       this.displayModal("Trading closed until next player's turn");
-      this.overlay.hide();  
+      this.overlay.hide();
+      this.tradeWindowOpen = false;  
     }
     
     let nodes = document.querySelectorAll(".pbtrade");
@@ -3174,156 +3234,7 @@ class Settlers extends GameTemplate {
     this.endTurn();
   }
 
-  /*
-    Interface to let player create and submit a trade offer based on the resources they and their opponent have
-  */
-  playerTrade() {
-    let settlers_self = this;
-    let html = '<div class="tbd">Pick Counterparty:';
 
-    html += "<ul>";
-    html += '<li class="option" id="bank">bank</li>';
-
-    if (this.game.players.length > 2)
-      html += `<li class="option" id="open">open offer</li>`;
-
-    for (let i = 0; i < this.game.players.length; i++) {
-      if (i + 1 != this.game.player) {
-        html +=
-          '<li class="option" id="' + (i + 1) + '">player ' + (i + 1) + "</li>";
-      }
-    }
-    html += `<li class="option" id="cancel">go back</li>`;
-    html += "</ul>";
-    html += "</div>";
-
-    this.updateStatus(html, 1);
-
-    //Select a player to query their resources and launch trade protocol
-    $(".option").off();
-    $(".option").on("click", function () {
-      //We use other functions for trading with the bank or broadcasting an offer to all the other players
-      let option = $(this).attr("id");
-      switch (option) {
-        case "bank":
-          settlers_self.bankTrade();
-          break;
-        case "open":
-          settlers_self.showTradeOverlay(0);
-          break;
-        case "cancel":
-          settlers_self.playerPlayMove();
-          break;
-        default:
-          settlers_self.privateTrade(option);
-      }
-    });
-  }
-
-  //Create a private trade offer with a given player in your playerbox-plog (status)
-  privateTrade(player) {
-    let settlers_self = this;
-    let my_resources = {};
-    let their_resources = {};
-    let offer_resources = settlers_self.skin.resourceObject();
-    let receive_resources = settlers_self.skin.resourceObject();
-
-    //Convert the players array of resources into a compact object {wheat:1, wood:2,...}
-    for (let resource of settlers_self.skin.resourceArray()) {
-      let temp = settlers_self.countResource(
-        settlers_self.game.player,
-        resource
-      );
-      if (temp > 0) my_resources[resource] = temp;
-    }
-
-    //>>>This is bad design, allows us to see other players resources... (which shouldn't be easy without scrolling through the log)
-    for (let resource of settlers_self.skin.resourceArray()) {
-      let temp = settlers_self.countResource(player, resource);
-      if (temp > 0) their_resources[resource] = temp;
-    }
-
-    //Player recursively selects all the resources they want to trade
-    let resourcesOfferInterface = function (settlers_self, player) {
-      let html = "<div class='tbd'>Select Resources to Offer: <ul>";
-      for (let i in my_resources) {
-        html += `<li id="${i}" class="option">${i} (${offer_resources[i]}/${my_resources[i]})</li>`;
-      }
-      html += '<li id="confirm" class="option">confirm offer</li>';
-      html += '<li id="cancel" class="option">cancel trade</li>';
-      html += "</ul>";
-      html += "</div>";
-
-      settlers_self.updateStatus(html, 1);
-
-      $(".option").off();
-      $(".option").on("click", function () {
-        let res = $(this).attr("id");
-        if (res == "confirm") {
-          resourcesReceiveInterface(settlers_self, player);
-          return;
-        }
-        if (res == "cancel") {
-          settlers_self.endTurn();
-          return;
-        }
-
-        if (offer_resources[res] < my_resources[res]) offer_resources[res]++;
-
-        resourcesOfferInterface(settlers_self, player);
-      });
-    };
-
-    //Player recursively selects the resources they want to receive
-    let resourcesReceiveInterface = function (settlers_self, player) {
-      let html =
-        "<div class='sf-readable'>Select Resources to Ask For: </div><ul>";
-      for (let i in their_resources) {
-        html += `<li id="${i}" class="option">${i} (${receive_resources[i]}/${their_resources[i]})</li>`;
-      }
-
-      html += '<li id="confirm" class="option">confirm ask</li>';
-      html += '<li id="cancel" class="option">cancel trade</li>';
-      html += "</ul>";
-
-      settlers_self.updateStatus(html, 1);
-
-      $(".option").off();
-      $(".option").on("click", function () {
-        let res = $(this).attr("id");
-
-        if (res == "confirm") {
-          settlers_self.updateStatus(
-            "<div class='tbd'>Sending Trade Offer</div>"
-          );
-          settlers_self.addMove(
-            "offer\t" +
-              settlers_self.game.player +
-              "\t" +
-              player +
-              "\t" +
-              JSON.stringify(offer_resources) +
-              "\t" +
-              JSON.stringify(receive_resources)
-          );
-          settlers_self.endTurn();
-          return;
-        }
-
-        if (res == "cancel") {
-          settlers_self.endTurn();
-          return;
-        }
-
-        if (receive_resources[res] < their_resources[res])
-          receive_resources[res]++;
-
-        resourcesReceiveInterface(settlers_self, player);
-      });
-    };
-
-    resourcesOfferInterface(settlers_self, player);
-  }
 
   /*<><><><><><><>
   Broadcast offer to trade to all players
@@ -3334,6 +3245,7 @@ class Settlers extends GameTemplate {
   showTradeOverlay(tradeType = -1) {
     let settlers_self = this;
 
+    this.tradeWindowOpen = true;
     let my_resources = {};
     let resources = settlers_self.skin.resourceArray();
     let offer_resources = settlers_self.skin.resourceObject();
@@ -3431,6 +3343,7 @@ class Settlers extends GameTemplate {
       });
 
       $(".trade_overlay_broadcast_button").on("click", function () {
+        settlers_self.tradeWindowOpen = false;
         if (tradeType > 0) {
           settlers_self.addMove(
             `offer\t${settlers_self.game.player}\t
@@ -3459,7 +3372,7 @@ class Settlers extends GameTemplate {
   }
 
   /*
-  Alternate UI
+  Alternate UI for advertizing your wants and needs
   */
   showResourceOverlay() {
     let settlers_self = this;
@@ -3788,12 +3701,14 @@ class Settlers extends GameTemplate {
         });
       });
     } else {
-      this.playerAcknowledgeNotice(
-        "ACKNOWLEDGE\t<div class='tbd'>You don't have enough resources to trade with the bank</div>",
-        function () {
-          settlers_self.endTurn();
-        }
-      );
+      let ackhtml = `<div class='tbd'>You don't have enough resources to trade with the bank</div> 
+                    <ul><li class="option" id="okay">okay</li></ul>`;
+      settlers_self.updateStatus(ackhtml,1);
+      $(".option").off();
+      $(".option").on("click",function(){
+        settlers_self.playerPlayMove();
+        return;
+      });
     }
   }
 

--- a/mods/settlers/settlers.js
+++ b/mods/settlers/settlers.js
@@ -542,6 +542,7 @@ class Settlers extends GameTemplate {
       if (mv[0] == "init") {
         //this.game.queue.splice(qe, 1);   // no splice, we want to bounce off this
         this.game.state.placedCity = null; //We are in game play mode, not initial set up
+        $(".diceroll").css("display","flex");
         for (let i = this.game.players.length; i > 0; i--) {
           //count backwards so it goes P1, P2, P3,
           this.game.queue.push(`play\t${i}`);
@@ -1211,6 +1212,12 @@ class Settlers extends GameTemplate {
 
         this.game.state.playerTurn = player;
         this.playerbox.insertGraphic("diceroll",player);
+        this.playerbox.addClass('flash');
+        setTimeout(() => {
+              $(".flash").removeClass("flash");
+            }, 3000);
+      
+
 
         if (this.game.player == player) {
           /*

--- a/mods/settlers/settlers.js
+++ b/mods/settlers/settlers.js
@@ -13,8 +13,8 @@ class Settlers extends GameTemplate {
     this.app = app;
 
     this.name = "Settlers";
-    this.gamename = "Settlers of Saito";
-    this.description = `Island colonization and settlement game. Collect resources and build your way to dominance.`;
+    this.gamename = "Settlers of Saitoa";
+    this.description = `Explore the island of Saitoa, collect resources, and build your way to dominance.`;
     this.categories = "Games Arcade Entertainment";
     this.type = "Strategy Boardgame";
     this.status = "Beta";
@@ -120,6 +120,21 @@ class Settlers extends GameTemplate {
 
     return html;
   }
+
+  returnWelcomeOverlay(){
+    let html = `<div class="rules-overlay trade_overlay">
+                <h1>Welcome to the Island of Saitoa</h1>
+                <h2>Initial Placement Phase</h2>
+                <p>Every one gets to start by placing two ${this.skin.c1.name}s anywhere on the board, each with an attached ${this.skin.r.name}. ${this.skin.c1.name}s go on the corners of the hexagon tiles, while ${this.skin.r.name}s go on the edges. When the dice roll the number of that tile, adjacent ${this.skin.c1.name}s produce that resource.</p>
+                <p>In order to be fair, the players take turns making their initial placement first in last out, i.e. the first player to place their first ${this.skin.c1.name} is the last player to place their second ${this.skin.c1.name}. You begin the game with the resources adjacent to your second ${this.skin.c1.name}.</p>
+                <h2>Good Luck!</h2>
+                <p>For more detailed instructions of the game, see "RULES" under the game menu. For detailed instructions on trading, refer to the "HELP" item under the trade menu.</p>
+                <div class="button close_welcome_overlay" id="close_welcome_overlay">Start Playing</div>
+                </div>
+  `;
+    return html;
+  }
+
 
   /*
   Make Overlay of game introduction/Rules
@@ -506,6 +521,7 @@ class Settlers extends GameTemplate {
     state.ports = [];
     state.lastroll = [];
     state.placedCity = "hello world"; //a slight hack for game iniitalization
+    state.welcome = 0;
     for (let i = 0; i < this.game.players.length; i++) {
       state.players.push({});
       state.players[i].resources = [];
@@ -548,15 +564,17 @@ class Settlers extends GameTemplate {
       /* Game Setup */
 
       if (mv[0] == "init") {
-        this.game.queue.splice(qe, 1);   // no splice, we want to bounce off this
+        this.game.queue.splice(qe, 1);   
         this.game.state.placedCity = null; //We are in game play mode, not initial set up
-        $(".diceroll").css("display");
+        this.game.state.lastroll = [0,0];
+        this.displayDice();
+        $(".diceroll").css("display","");
         this.game.queue.push("round");
         this.displayModal("Now we begin game play");
         return 1;
       }
 
-      if (mv[0] == "round"){
+      if (mv[0] == "round"){ // no splice, we want to bounce off this
         for (let i = this.game.players.length; i > 0; i--) {
           //count backwards so it goes P1, P2, P3,
           this.game.queue.push(`play\t${i}`);
@@ -767,6 +785,16 @@ class Settlers extends GameTemplate {
         let player = parseInt(mv[1]);
         this.game.queue.splice(qe, 1);
         this.stopTrading();
+
+        //For the beginning of the game only...
+        if (this.game.state.welcome == 0 && this.browser_active) {
+            this.overlay.show(this.app, this, this.returnWelcomeOverlay());
+            document.querySelector(".close_welcome_overlay").onclick = (e) => {
+              this.overlay.hide();
+            };
+          this.game.state.welcome = 1;
+        }
+
         if (this.game.player == player) {
           this.playerBuildCity(mv[1]);
         } else {

--- a/mods/settlers/web/style.css
+++ b/mods/settlers/web/style.css
@@ -166,7 +166,6 @@ body {
 
 /* Dice */
 .diceroll{
-  display: none;
   width: min(12vw,120px);
   margin: 0 auto;
   /*position: absolute;
@@ -177,7 +176,7 @@ body {
   border-radius: 5px;
   background-color: #222B;
   padding: min(0.5vw,5px);
-  display: none; /*flex;*/
+  display: flex;
   flex-direction: row;
   justify-content: space-evenly;
   z-index: 3;
@@ -891,7 +890,7 @@ ul.horizontal_list li.iconoption{
 .flash {
   animation-name: flash;
   animation-duration: .8s;
-  animation-iteration-count: 2;
+  animation-iteration-count: 3;
   animation-fill-mode: backwards;
 }
 

--- a/mods/settlers/web/style.css
+++ b/mods/settlers/web/style.css
@@ -17,6 +17,7 @@
   padding: 0.5em 1em;
   box-sizing: content-box;
   white-space: nowrap;
+  pointer-events: none;
   z-index: 300;
 }
 
@@ -484,7 +485,7 @@ body {
   background-color: black;
   color: darkgray;
   border-color: black;
-  box-shadow: 0 0 40px 50px rgba(0,0,0,0.75);
+  box-shadow: 0 0 25px 45px rgba(0,0,0,0.75);
 }
 
 .city.p1 {
@@ -872,7 +873,7 @@ ul.horizontal_list li.iconoption{
   font-size: 1.25em;
   width: 100%;
   text-align: center;
-  margin: 2em 0;
+  margin: 1em 0;
 }
 
 .stats-table caption{
@@ -889,14 +890,17 @@ ul.horizontal_list li.iconoption{
   text-align: left;
 }
 
-.stats-table .icon{
+.stats-table .icon, .stats-table .token{
   width: 50px;
+  height: 50px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
 }
-
 
 .flash {
   animation-name: flash;
-  animation-duration: .8s;
+  animation-duration: 1.3s;
   animation-iteration-count: 3;
   animation-fill-mode: backwards;
 }

--- a/mods/settlers/web/style.css
+++ b/mods/settlers/web/style.css
@@ -177,7 +177,7 @@ body {
   border-radius: 5px;
   background-color: #222B;
   padding: min(0.5vw,5px);
-  display: flex;
+  display: none; /*flex;*/
   flex-direction: row;
   justify-content: space-evenly;
   z-index: 3;
@@ -433,6 +433,7 @@ body {
 
 .player-box.me{
   border-top: 10px solid;
+  border-right: 10px solid;
 }
 .player-box.notme{
   border-left: 10px solid;
@@ -884,6 +885,25 @@ ul.horizontal_list li.iconoption{
 
 .stats-table .icon{
   width: 50px;
+}
+
+
+.flash {
+  animation-name: flash;
+  animation-duration: .8s;
+  animation-iteration-count: 2;
+  animation-fill-mode: backwards;
+}
+
+@keyframes flash {
+  0% {
+    opacity: .8;
+    background-color: white;
+    color: black !important;
+  }
+  100% {
+    opacity: 1;
+  }
 }
 
 

--- a/mods/settlers/web/style.css
+++ b/mods/settlers/web/style.css
@@ -164,34 +164,7 @@ body {
   box-shadow: unset;
 }
 
-/* Dice */
-.diceroll{
-  width: min(12vw,120px);
-  margin: 0 auto;
-  /*position: absolute;
-  /*top: 0px;
-  left: 50%;
-  transform: translateX(-5vw);*/
-  border: 2px solid black;
-  border-radius: 5px;
-  background-color: #222B;
-  padding: min(0.5vw,5px);
-  display: flex;
-  flex-direction: row;
-  justify-content: space-evenly;
-  z-index: 3;
-}
 
-.die{
-  width: min(4vw,40px);
-}
-.hud-body {
-  overflow: unset;
-}
-
-.textchoice {
-  
-}
 
 .status-message ul li:hover, .status ul li:hover, .cardselector:hover{
   color: black;
@@ -543,6 +516,10 @@ body {
   /*overflow-y: scroll;*/
 }
 
+.rules-overlay{
+  overflow-y: scroll;
+}
+
 .trade_overlay_title{
   width: 100%;
   text-align: center;
@@ -675,7 +652,7 @@ ul.horizontal_list li.iconoption{
 .me > .player-box-graphic{
   position: absolute;
   /*left: calc(150px + 8vw);*/
-  bottom: calc(100% + 10px);
+  bottom: calc(100% + 12px);
   left: 50%;
   transform: translateX(-50%);
 }
@@ -683,12 +660,42 @@ ul.horizontal_list li.iconoption{
 .notme > .player-box-graphic{
   position: absolute;
   top: 50%;
-  right: calc(100% + 10px);
+  right: calc(100% + 12px);
   transform: translateY(-50%);
   /*position: relative;
   z-index: -1;
   top: 5vh;
   left: 1vw;*/
+}
+
+
+/* Dice */
+.diceroll{
+  width: min(12vw,110px);
+  margin: 0 auto;
+  /*position: absolute;
+  /*top: 0px;
+  left: 50%;
+  transform: translateX(-5vw);*/
+  border: 2px solid black;
+  border-radius: 5px;
+  background-color: #222B;
+  padding: min(0.5vw,5px) 0;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-evenly;
+  z-index: 3;
+}
+
+.die{
+  width: min(4vw,40px);
+}
+
+.notme .diceroll{
+  width: 50px;
+  height: min(12vw, 110px);
+  padding: 0 min(0.5vw,5px);
+  flex-direction: column;
 }
 
 .flexline{
@@ -922,13 +929,20 @@ ul.horizontal_list li.iconoption{
   }
  
   .notme > .player-box-graphic{
-    top: unset;
     right: unset;
     position: absolute;
-    bottom: calc(100% + 5px);
+    top: calc(100% + 5px);
     left: 50%;
     transform: translateX(-50%);
 }   
+
+  .notme .diceroll{
+    width: min(12vw, 110px);
+    height: 50px;
+    padding: min(0.5vw,5px) 0 ;
+    flex-direction: row;
+}
+
 }
 
 /*Still need better layout for small screens*/

--- a/web/saito/lib/templates/game.css
+++ b/web/saito/lib/templates/game.css
@@ -1322,6 +1322,18 @@ i.menu_icon_icon{
   top: 13vh;
 }
 
+.staggered-hand>.card:nth-child(2){
+  top: 4vh;
+}
+.staggered-hand>.card:nth-child(3){
+  top: 8vh; 
+}
+.staggered-hand>.card:nth-child(4){
+  top: 12vh;
+}
+.staggered-hand>.card:nth-child(5){
+  top: 16vh;
+}
 
 /** MOBILE STYLING FOR CARDFAN**/
 @media screen and (orientation: landscape) and (max-height: 600px) {


### PR DESCRIPTION
Fixes #361 and #362

-- Add victory points break down in stats overlay with auto ranking of players
-- Changed header of stats overlay at end of game to announce winner
-- tweaked look of robber to interfere less with game pieces
-- fixed display of resource menu choices for monopoly/bounty
-- default to showing player resources when playing monopoly/bounty (361)
-- created new class to stagger development cards and make them more readable
-- improved display of playerBox trade offers
-- limit salert to incoming trades that are acceptable 
-- advertisement window will not auto close when trading is banned, but trade offer window will auto close with a modal message
-- checked logic for bank trading and removed playerAcknowledgeNotice (362)
-- made tooltips less intrusive
