### PR TITLE
fixed up game-crypto-transfer-manager ui in arcade and poker

### DIFF
--- a/lib/saito/ui/game-crypto-transfer-manager/game-crypto-transfer-manager-balance.template.js
+++ b/lib/saito/ui/game-crypto-transfer-manager/game-crypto-transfer-manager-balance.template.js
@@ -1,4 +1,4 @@
-module.exports = GameCryptoTransferManagerSendTemplate = (app, sobj) => {
+module.exports = GameCryptoTransferManagerBalanceTemplate = (app, sobj) => {
 
   return `  
   <div class="game-crypto-transfer-manager-container">
@@ -7,10 +7,16 @@ module.exports = GameCryptoTransferManagerSendTemplate = (app, sobj) => {
 
     <div class="to_address">${sobj.address}</div>
 
+    <div id="crypto_balance" class="balance hidden"></div>
+
     <img style="margin-top: 20px" class="spinner" src="/website/img/spinner.svg" />
+
+    <div class="button crypto_transfer_btn hidden" id="crypto_balance_btn">confirm</div>
 
   </div>
   `;
 
 }
 
+
+  

--- a/lib/saito/ui/game-crypto-transfer-manager/game-crypto-transfer-manager-receive.template.js
+++ b/lib/saito/ui/game-crypto-transfer-manager/game-crypto-transfer-manager-receive.template.js
@@ -8,6 +8,7 @@ module.exports = GameCryptoTransferManagerReceive = (app, sobj) => {
     <div class="amount">${sobj.amount} ${sobj.ticker}</div>
 
     <img class="spinner" src="/website/img/spinner.svg" />
+    <div class="amount hidden" id="cryptoManagerFeedback"></div>
 
     <div class="transfer-details">
       <div class="send_to">from</div>
@@ -15,6 +16,8 @@ module.exports = GameCryptoTransferManagerReceive = (app, sobj) => {
       <div class="send_to">to</div>
       <div class="to_address">${sobj.to}</div>
     </div>
+
+    <div class="button hidden crypto_transfer_btn" id="crypto_receipt_btn">confirm</div>
 
   </div>
   `;

--- a/lib/saito/ui/game-crypto-transfer-manager/game-crypto-transfer-manager.js
+++ b/lib/saito/ui/game-crypto-transfer-manager/game-crypto-transfer-manager.js
@@ -41,7 +41,7 @@ class GameCryptoTransferManager {
  * @param ticker {string} - name of a currency
  * @mycallback - an optional callback function that never gets called
  */ 
-    returnBalance(app, mod, address, ticker, mycallback=null) {
+    async returnBalance(app, mod, address, ticker, mycallback=null) {
 
       let sobj = {};
           sobj.address = address;
@@ -49,7 +49,30 @@ class GameCryptoTransferManager {
 
       this.overlay.show(app, mod, GameCryptoTransferManagerBalanceTemplate(app, sobj));
       this.overlay.blockClose();
+      let cryptoMod = app.wallet.returnCryptoModuleByTicker(ticker);
+      let current_balance = await cryptoMod.returnBalance();
 
+      let spinner = document.querySelector(".spinner");
+      if (spinner) {spinner.remove();}
+
+      let balanceDiv = document.querySelector("#crypto_balance");
+      let confirmBtn = document.querySelector("#crypto_balance_btn");
+
+      if (balanceDiv){
+        balanceDiv.textContent = (current_balance) ? sanitize(current_balance) : "Crypto unavailable";
+        balanceDiv.classList.remove("hidden");  
+      }
+      
+      if (confirmBtn){
+        confirmBtn.classList.remove("hidden");
+        confirmBtn.onclick = (e) =>{
+          this.hideOverlay(mycallback);
+        };         
+      }else{
+        this.hideOverlay(mycallback);  
+        
+      }
+      return current_balance;
     }
 
 
@@ -92,7 +115,7 @@ class GameCryptoTransferManager {
  * @param ticker {string} - name of a currency
  * @mycallback - an optional callback function to run on confirmation
  */ 
-    receivePayment(app, mod, sender, receiver, amount, ts, ticker, mycallback=null) {
+    async receivePayment(app, mod, sender, receiver, amount, ts, ticker, mycallback=null) {
 
       let sobj = {};
           sobj.amount = amount;
@@ -103,7 +126,15 @@ class GameCryptoTransferManager {
       this.overlay.show(app, mod, GameCryptoTransferManagerReceiveTemplate(app, sobj));
       this.overlay.blockClose();
 
-      if (mycallback != null) { mycallback(); }
+      if (mycallback != null) { mycallback(document.querySelector("#cryptoManagerFeedback")); }
+
+      let confirmBtn = document.querySelector("#crypto_receipt_btn");
+      
+      if (confirmBtn){
+        confirmBtn.onclick = (e) =>{
+          this.hideOverlay();
+        };         
+      }
 
     }
 

--- a/lib/templates/gametemplate.js
+++ b/lib/templates/gametemplate.js
@@ -4526,7 +4526,7 @@ console.log("DECKXOR HERE: " + JSON.stringify(gmv));
         let receiver = gmv[2];
         let amount = gmv[3];
         let ts = gmv[4];
-	let unique_hash = gmv[5];
+      	let unique_hash = gmv[5];
         let ticker = game_self.game.crypto;
         if (gmv[6]) { ticker = gmv[6]; }
 
@@ -4535,7 +4535,7 @@ console.log("DECKXOR HERE: " + JSON.stringify(gmv));
         //
         // note: senders identified by Saito publickey not other in this function
         //
-        if (!this.app.wallet.returnPublicKey() === sender) {
+        if (this.app.wallet.returnPublicKey() !== sender) {
           game_self.game.queue.splice(game_self.game.queue.length - 1, 1);
           return 1;
         }
@@ -4588,7 +4588,7 @@ console.log("DECKXOR HERE: " + JSON.stringify(gmv));
 
         });
 
-	return 0;
+	     return 0;
       }
       return 1;
     });
@@ -4639,34 +4639,55 @@ console.log("DECKXOR HERE: " + JSON.stringify(gmv));
         if (gmv[6]) { ticker = gmv[6]; }
 
 
-	//
-	// if we are the sender, lets get sending and receiving addresses
-	//
-	let sender_crypto_address = "";
-	let receiver_crypto_address = "";
+        //
+        // if we are not the receiver, we do not need to worry and can continue
+        //
+        // note: senders identified by Saito publickey not other in this function
+        //
+        if (this.app.wallet.returnPublicKey() !== receiver) {
+          game_self.game.queue.splice(game_self.game.queue.length - 1, 1);
+          return 1;
+        }
+
+
+      	//
+      	// if we are the sender, lets get sending and receiving addresses
+      	//
+      	let sender_crypto_address = "";
+      	let receiver_crypto_address = "";
         for (let i = 0; i < game_self.game.players.length; i++) {
-	  if (game_self.game.players[i] === sender) { sender_crypto_address = game_self.game.keys[i]; }
-	  if (game_self.game.players[i] === receiver) { receiver_crypto_address = game_self.game.keys[i]; }
-	}
+      	  if (game_self.game.players[i] === sender) { sender_crypto_address = game_self.game.keys[i]; }
+      	  if (game_self.game.players[i] === receiver) { receiver_crypto_address = game_self.game.keys[i]; }
+      	}
 
         let my_specific_game_id = game_self.game.id;
         game_self.saveGame(game_self.game.id);
         game_self.game.halted = 1;
 
-        game_self.crypto_transfer_manager.receivePayment(this.app, this, [sender.split("|")[0]], [receiver.split("|")[0]], [amount], ts, ticker, function() {
+        game_self.crypto_transfer_manager.receivePayment(this.app, this, [sender.split("|")[0]], [receiver.split("|")[0]], [amount], ts, ticker, function(divname) {
           game_self.app.wallet.receivePayment([sender_crypto_address], [receiver_crypto_address], [amount], ts, unique_hash, function(robj) {
-            game_self.crypto_transfer_manager.hideOverlay();
-
+            //Update crypto-transfer-manager
+            if (document.querySelector(".spinner")){
+              document.querySelector(".spinner").remove();
+            }
+            $(".game-crypto-transfer-manager-container .hidden").removeClass("hidden");
+            if (divname){
+              if (robj){ //==1, success
+                divname.textContent = "Success"; 
+              }else{ //==0, failure
+                divname.textContent = "Failed";
+              }
+            }
             if (game_self.game.id != my_specific_game_id) { game_self.game = game_self.loadGame(my_specific_game_id); }
 
-            game_self.updateLog("payments issued...");
+            game_self.updateLog("payments received...");
             game_self.game.queue.splice(game_self.game.queue.length-1, 1);
             game_self.game.halted = 0;
 
             //
             // and save so we continue from AFTER this point if the game 
-	    // is reloaded...
-	    //
+      	    // is reloaded...
+      	    //
             game_self.saveGame(game_self.game.id);
 
             let cont = game_self.runQueue();
@@ -4678,7 +4699,7 @@ console.log("DECKXOR HERE: " + JSON.stringify(gmv));
 
           return 0;
         });
-	return 0;
+	      return 0;
       }
       return 1;
     });

--- a/mods/arcade/lib/arcade-main/arcade-main.js
+++ b/mods/arcade/lib/arcade-main/arcade-main.js
@@ -285,23 +285,14 @@ module.exports = ArcadeMain = {
           salert(`You must set ${game_options.crypto} as your preferred crypto to join this game`);
           return;
         }
-        let cryptoMod = null;
-        try {
-          cryptoMod = app.wallet.returnCryptoModuleByTicker(game_options.crypto);
-        } catch (err) {
-          if (err.startsWith("Module Not Found")) {
-            salert("This game requires " + game_options.crypto + " crypto to play! Not Found!");
-            return;
-          } else {
-            throw err;
-          }
-        }
+      
+
 
         let c = await sconfirm("This game requires " + game_options.crypto + " crypto to play. OK?");
         if (!c) {
           return;
         }
-
+        console.log(game_options.stake);
         //
         // if a specific cost / stake specified
         //
@@ -309,18 +300,24 @@ module.exports = ArcadeMain = {
         if (parseFloat(game_options.stake) > 0) {
           let my_address = app.wallet.returnPreferredCrypto(game_options.crypto).returnAddress();
           let crypto_transfer_manager = new GameCryptoTransferManager(app);
-          crypto_transfer_manager.returnBalance(
+ //         try{
+           let current_balance = await crypto_transfer_manager.returnBalance(
             app,
             mod,
             my_address,
             game_options.crypto,
             function () { }
           );
-
-          let current_balance = await cryptoMod.returnBalance();
-
-          crypto_transfer_manager.hideOverlay();
-
+            console.log("Current balance", current_balance);
+/*          } catch (err) {
+            if (err.startsWith("Module Not Found")) {
+              salert("This game requires " + game_options.crypto + " crypto to play! Not Found!");
+              return;
+            } else {
+              throw err;
+            }
+          }
+*/
           try {
             if (BigInt(current_balance) < BigInt(game_options.stake)) {
               salert("You do not have enough " + game_options.crypto + "! Balance: " + current_balance);
@@ -335,7 +332,7 @@ module.exports = ArcadeMain = {
         }
       }
     } catch (err) {
-      console.log("ERROR checking if crypto-required: " + err);
+     console.log("ERROR checking if crypto-required: " + err);
       return;
     }
 


### PR DESCRIPTION
-- some light reworking of GameCryptoTransferManager (See #101)
    ++ Key thing is adding buttons to close balance/receive overlay (instead of programatically closing them, which happens so fast no one can see anything)
    ++ balance & receive replace the spinner with either the balance or a success message when those async functions complete
    ++ moved balance checking from Arcade (arcade-game-details + arcade-main.joinGame) into the gameCryptoTransferManager
-- edited Arcade to query balance for both initiator of game and players joining game when crypto is involved
-- edited Poker to calculate amount of crypto to send and fix JS float issues
-- cleaned up SEND/RECEIVE functions in the game engine to only be processed by the involved parties
