### PR TITLE
demo of how difficulty adjustment can be made granular

### DIFF
--- a/lib/saito/block.ts
+++ b/lib/saito/block.ts
@@ -462,14 +462,17 @@ class Block {
 
       if (previous_block.hasGoldenTicket() && cv.gt_num === 0) {
         if (difficulty > 0) {
-          cv.expected_difficulty = previous_block.returnDifficulty() - 1;
+          cv.expected_difficulty = Math.floor(previous_block.returnDifficulty() * 0.9);
+          console.log("Difficulty adjusted down to: " + cv.expected_difficulty);
         }
       } else if (previous_block.hasGoldenTicket() && cv.gt_num > 0) {
-        cv.expected_difficulty = difficulty + 1;
+        cv.expected_difficulty = Math.ceil(difficulty * 1.1);
+        console.log("Difficulty adjusted up to: " + cv.expected_difficulty);
+
       } else {
         cv.expected_difficulty = difficulty;
       }
-
+ 
       //
       // average income and variance depends on previous block too
       //

--- a/lib/saito/goldenticket.ts
+++ b/lib/saito/goldenticket.ts
@@ -13,7 +13,7 @@ class GoldenTicket {
     }
 
     const solution = this.app.crypto.hash(previous_block_hash + random_hash + publickey);
-    const leading_zeroes_required = Math.floor(difficulty / 16);
+    const leading_zeroes_required = Math.floor(Math.log(difficulty)/Math.log(16));
     const final_digit = 15 - (difficulty % 16);
 
     //


### PR DESCRIPTION
Made and tested changes in block.ts and goldenticket.js that change the curve and method of difficulty adjustment.

Difficuly is adjusted as a multiple - not an integer change in number of leading zeros, by changing the method of calculating the leading zeros to the be the base 16 log of the difficulty number, rather than it's value divided by 16 rounded down. 

Difficulty adjustment is changed to be a multiple (up = * 1.1, down = * 0.9 - as this is a prototype) rounded to an integer.

This creates a smooth, rather than sawtooth difficulty curve.