### PR TITLE
fix: noisy error in SaitoOverlay

### DIFF
--- a/lib/saito/ui/saito-overlay/saito-overlay.js
+++ b/lib/saito/ui/saito-overlay/saito-overlay.js
@@ -44,9 +44,8 @@ class SaitoOverlay {
    * @param mycallback - a function to run when the user closes the overlay
    *
    */
-  show(app, mod, html, mycallback = null, eventCallback = null) {
+  show(app, mod, html = "", mycallback = null, eventCallback = null) {
     this.render(app, mod);
-
 
     let overlay_self = this;
 
@@ -60,21 +59,25 @@ class SaitoOverlay {
       if (this.closebox) {
         overlay_el.innerHTML =
           `<div id="saito-overlay-closebox" class="saito-overlay-closebox"><i class="fas fa-times-circle saito-overlay-closebox-btn"></i></div>` +
-          html;
+          sanitize(html);
         //Close by clicking on closebox
         let closebox_el = document.querySelector(".saito-overlay-closebox");
         closebox_el.onclick = (e) => {
           overlay_self.hide(mycallback);
         };
       } else {
-        overlay_el.innerHTML = html;
+        overlay_el.innerHTML = sanitize(html);
       }
 
       overlay_backdrop_el.onclick = (e) => {
 
         overlay_self.hide(mycallback);
       };
-      this.attachEvents(app, mod, eventCallback);
+
+      if (eventCallback !== null){
+        this.attachEvents(app, mod, eventCallback);  
+      }
+      
     } catch (err) {
       console.error("OVERLAY ERROR:", err);
     }


### PR DESCRIPTION
Just wrapping an if statement around the new attachEvents (@davikstone2) added, so it doesn't try running null as a function. Sure the try/catch block doesn't break the code, but it spams the log with an error. : )