### PR TITLE
League: create semi-private game invitations

### DIFF
--- a/lib/templates/gametemplate.js
+++ b/lib/templates/gametemplate.js
@@ -2417,6 +2417,10 @@ console.log("DONE INITIALIZE GAME FEEDER!: " + this.name);
         if (i == "observer" && options[i] != "enable") {
           output_me = 0;
         }
+        if (i == "league"){
+          output_me = 0;
+          sgo[i] = null;
+        }
         if (i == "game-wizard-players-select") {
           output_me = 0;
         }

--- a/mods/arcade/lib/arcade-game/arcade-game-details.js
+++ b/mods/arcade/lib/arcade-game/arcade-game-details.js
@@ -178,6 +178,16 @@ module.exports = ArcadeGameDetails = {
              console.log("ERROR checking crypto: " + err);
             return;
           }
+
+          //Check League Membership
+          if (options.league){
+            let leag = app.modules.returnModule("League");
+            if (!leag.isLeagueMember(options.league)){
+              salert("You need to be a member of the League to create a League-only game invite");
+              return;
+            }
+          }
+
           let gamemod = app.modules.returnModule(options.game);
           let players_needed = 0;
           if (document.querySelector(".game-wizard-players-select")) {

--- a/mods/arcade/lib/arcade-game/arcade-game-details.template.js
+++ b/mods/arcade/lib/arcade-game/arcade-game-details.template.js
@@ -24,6 +24,7 @@ module.exports = ArcadeGameDetailsTemplate = (app, mod, invite) => {
           <div class="game-wizard-image"><img class="game-image" src="${gamemod_url}"/></div>
           <div class="game-wizard-intro">
             <input type="hidden" name="game" value="${invite.msg.game}" />
+            ${(invite.msg.league)? `<input type="hidden" name="league" value="${invite.msg.league}" />` : ""}
             <div class="game-wizard-title"><span class="game-home-link">${game_name}</span></div>
             <div class="game-wizard-description">${mod.description} </div>
             <div class="game-wizard-post-description">[<span id="game-rules-btn" class="game-help-link">how to play</span>]</div>
@@ -45,7 +46,7 @@ module.exports = ArcadeGameDetailsTemplate = (app, mod, invite) => {
       }else{
         html += `<div class="dynamic_button saito-select">
                  <div class="dynamic_button_options saito-slct">
-                    <button type="button" id="game-invite-btn" class="game-invite-btn" data-type="open">Create Open Game</button>
+                    <button type="button" id="game-invite-btn" class="game-invite-btn" data-type="open">Create ${(invite.msg.league)?"League":"Open"} Game</button>
                     <button type="button" id="game-invite-btn" class="game-invite-btn tip" data-type="private">Create Private Game<div class="tiptext">Other players on the Saito network will not see this game and can only join if you provide them the invitation link</div></button>
                  </div>
                  </div>

--- a/mods/league/league.js
+++ b/mods/league/league.js
@@ -994,6 +994,20 @@ class League extends ModTemplate {
     return 0;
   }
 
+  //API Function
+  isLeagueMember(league_id){
+    for (let leag of this.leagues){
+      if (leag.id == league_id){
+        if (leag.myRank > 0){
+          return true;
+        }else{
+          return false;
+        }
+      }
+    }
+    return false;
+  }
+
 
 }
 

--- a/mods/league/lib/overlays/arcade-league-view.js
+++ b/mods/league/lib/overlays/arcade-league-view.js
@@ -1,5 +1,7 @@
 const ArcadeLeagueViewTemplate = require("./arcade-league-view.template");
 const SaitoOverlay = require("../../../../lib/saito/ui/saito-overlay/saito-overlay");
+const saito = require("../../../../lib/saito/saito");
+
 module.exports = ArcadeLeagueView = {
 
   render(app, mod, league) {
@@ -110,6 +112,19 @@ module.exports = ArcadeLeagueView = {
     if (inviteBtn){
       inviteBtn.onclick = () => {
         mod.showShareLink(this.league.id, app.modules.returnActiveModule());
+      }
+    }
+
+    //ActiveModule should be Arcade
+    //We only render the button in the template if that is the case
+    let createGameBtn = document.getElementById("game-invite-btn");
+    if (createGameBtn){
+      createGameBtn.onclick = () => {
+        let tx = new saito.default.transaction();
+        tx.msg.game = this.league.game;
+        tx.msg.league = this.league.id;
+        ArcadeGameDetails.render(app, app.modules.returnActiveModule(), tx);
+        ArcadeGameDetails.attachEvents(app, app.modules.returnActiveModule(), tx);
       }
     }
 

--- a/mods/league/lib/overlays/arcade-league-view.template.js
+++ b/mods/league/lib/overlays/arcade-league-view.template.js
@@ -15,8 +15,11 @@ module.exports = ArcadeLeagueTemplate = (app, mod, league) => {
       <div class="info-item"><div>Type:</div><div>${league.type}</div></div>
       <div class="info-item"><div>Ranking Algo:</div><div>${league.ranking}</div></div>
       <div class="info-item"><div>Admin:</div><div>${app.keys.returnUsername(league.admin)}</div></div>
-    </div>
-    <div id="league-leaderboard" class="league-leaderboard">
+    </div>`;
+    if (app.modules.returnActiveModule().name == "Arcade" && league.game && league.myRank > 0 && league.admin !== "saito"){
+      html += `<div><button type="button" id="game-invite-btn" class="game-invite-btn" >Create Game</button></div>`;
+    }
+    html += `<div id="league-leaderboard" class="league-leaderboard">
       <div class="leaderboard-spinner loader"></div>
     </div>
     <div class="btn-controls-box">`;


### PR DESCRIPTION
Makes Leagues function more like leagues, where members can create a public game invite that is only available to other members of the league. Game invites should only be visible to league members or players eligible to join the league (who will be prompted to join the league before joining the game)