### PR TITLE
fix: removed wrongly commented out (and unnecessary) style block

### DIFF
--- a/mods/mahjong/web/style.css
+++ b/mods/mahjong/web/style.css
@@ -10,10 +10,6 @@ body {
   padding: 0 0 0 0 ;
 }
 
-/* .hidable {
-  /* color: whitesmoke; */
-} */
-
 .slot {
   background-color: blue;
   width: 100%;


### PR DESCRIPTION
## What
fix: removed wrongly commented out (and unnecessary) style block

<img width="1649" alt="Screenshot 2022-09-16 at 21 31 42" src="https://user-images.githubusercontent.com/11087605/190728084-68da8953-1882-4b0e-b969-c630ff026cd9.png">
