### PR TITLE
fix mouseover tiptext in redsquare

### DIFF
--- a/lib/saito/new-ui/templates/saito-arcade-invite.template.js
+++ b/lib/saito/new-ui/templates/saito-arcade-invite.template.js
@@ -27,7 +27,7 @@ module.exports = SaitoArcadeInviteTemplate = (app, mod, invite=null) => {
   for (let i = 0; i < numPlayerSlots; i++) {
     if (i < invite.msg.players.length) {
       let identicon = app.keys.returnIdenticon(invite.msg.players[i]);
-       playersHtml += `<div class="saito-arcade-invite-slot id-${invite.msg.players[i]}"><img class="saito-identicon small" src="${identicon}"></div>`;
+       playersHtml += `<div class="saito-arcade-invite-slot tip id-${invite.msg.players[i]}"><img class="saito-identicon small" src="${identicon}"><div class="tiptext">${app.browser.returnAddressHTML(invite.msg.players[i])}</div></div>`;
     } else {
       playersHtml += `<div class="saito-arcade-invite-slot identicon-empty"></div>`;  
     }

--- a/mods/redsquare/web/css/arcade.css
+++ b/mods/redsquare/web/css/arcade.css
@@ -7,6 +7,10 @@
     z-index: 1;
 }
 
+.tip:hover .tiptext {
+  visibility: visible;
+}
+
 .tiptext {
     width: 90%;
     min-width: 400px;


### PR DESCRIPTION
The identicons weren't showing user keys in RS for 2 reasons
1) tip:hover tiptext was not in redsquare/web/arcade.css (though is that the best place for it?? maybe move to saito-base.css??)
2) the new-ui/template didn't have the tip/tiptext combo for the game invite

Both are rectified
@arpee you may want to adjust the styling since it doesn't look great