### PR TITLE
refine checks for duplicate game invite listings

### DIFF
--- a/mods/arcade/arcade.js
+++ b/mods/arcade/arcade.js
@@ -1564,7 +1564,7 @@ class Arcade extends ModTemplate {
   }
 
   validateGame(tx) {
-    if (!tx?.transaction?.sig || !tx?.msg) {
+    if (!tx || !tx.msg || !tx.transaction || !tx.transaction.sig) {
       return false;
     }
 
@@ -1573,19 +1573,12 @@ class Arcade extends ModTemplate {
     }
 
     for (let i = 0; i < this.games.length; i++) {
-      let transaction = Object.assign({ sig: "" }, this.games[i].transaction);
-
-      if (tx.transaction.sig == transaction.sig) {
-        return false;
-      }
-      if (tx.returnMessage().game_id != "" && tx.returnMessage().game_id == transaction.sig) {
-        return false;
-      }
-      if (tx.returnMessage().game_id === this.games[i].transaction.sig) {
-        console.log("ERROR 480394: not re-adding existing game to list");
+      if (tx.transaction.sig === this.games[i].transaction.sig) {
+        console.log("TX is already in Arcade list");
         return false;
       }
     }
+
     return true;
   }
 
@@ -1706,9 +1699,7 @@ class Arcade extends ModTemplate {
 
 
   addGameToOpenList(tx) {
-    let valid_game = this.validateGame(tx);
-    
-    if (valid_game) {
+    if (this.validateGame(tx)) {
       this.games.unshift(tx);
       ArcadeMain.renderArcadeTab(this.app, this);
     }

--- a/mods/redsquare/lib/main.js
+++ b/mods/redsquare/lib/main.js
@@ -17,9 +17,6 @@ class RedSquareMain {
     this.app = app;
     this.name = "RedSquareMain";
 
-    // TODO -- HACK TO AVOID LEAGUES PROBLEM
-    this.left_sidebar_rendered = 0;
-
     //
     // left sidebar
     //
@@ -65,12 +62,7 @@ class RedSquareMain {
       app.browser.addElementToDom(RedSquareMainTemplate(app, mod));
     }
 
-    // TODO - remove when refactored
-    //if (this.left_sidebar_rendered === 0) {
-      mod.lsidebar.render(app, mod, ".saito-sidebar-left");
-      this.left_sidebar_rendered = 1;
-    //}
-
+    mod.lsidebar.render(app, mod, ".saito-sidebar-left");
     mod.home.render(app, mod, ".appspace");
     mod.rsidebar.render(app, mod, ".saito-sidebar-right");
 

--- a/mods/redsquare/lib/sidebar/games/games.js
+++ b/mods/redsquare/lib/sidebar/games/games.js
@@ -10,7 +10,6 @@ class RedSquareGames {
     this.app = app;
     this.mod = mod;
     this.selector = selector;
-    this.blockRender = false;
 
     app.connection.on("game-invite-list-update", () => {
         //console.log("Arcade update received");
@@ -20,8 +19,6 @@ class RedSquareGames {
   }
 
   render(app, mod, selector="") {
-    if (this.blockRender) { return; }
-
     if (selector != "") {
       this.selector = selector;
     }


### PR DESCRIPTION
I don't see how multiple copies of a game invite can show up in the list. When a game TX is added, Arcade checks if it is a duplicate. When RS renders, it builds the sidebar list from scratch.