### PR TITLE
Make game menu less obtrusive in Quake 3

### DIFF
--- a/mods/quake3/web/style.css
+++ b/mods/quake3/web/style.css
@@ -20,4 +20,13 @@
 .saito-userline {
   color: #999;
 }
-
+.game-menu {
+	opacity: 60%;
+	position: relative;
+	margin-left: auto;
+	margin-right: auto;
+    width:200px;
+}
+.game-menu:hover {
+	opacity: 90%;
+}


### PR DESCRIPTION
Moves Saito game menu to top center so it doesn't block Quake 3 chat +  killfeed. Makes it 60% transparent unless hovered over.