### PR TITLE
Make game menu less obtrusive in Quake 3 (attempt 2)

### DIFF
--- a/mods/quake3/web/style.css
+++ b/mods/quake3/web/style.css
@@ -20,4 +20,12 @@
 .saito-userline {
   color: #999;
 }
+.game-menu {
+  left: 50%;
+  transform: translate(-50%, 0);
+  opacity: 60%;
+}
 
+.game-menu:hover{
+  opacity: 90%;
+}


### PR DESCRIPTION
Kill feed and in game chat occupy top left, so center overlay menu away from that and add transparency unless hovered.