### PR TITLE
Poker3

### DIFF
--- a/lib/templates/gametemplate.js
+++ b/lib/templates/gametemplate.js
@@ -1500,11 +1500,7 @@ console.log("started queue done");
   processFutureMoves() {
     this.gaming_active = 0;
 
-    console.log(this.game.future.length + " FUTURE MOVES");
-    console.log("the moves ---> " + JSON.stringify(this.game.future));
-    console.log("game halted   --> " + this.game.halted);
-    console.log("game step --> " + this.game.step.game);
-    console.log("PLAYER: " + this.game.player);
+    console.log(this.game.future.length + " FUTURE MOVES at step --> " + this.game.step.game);
 
     if (this.game.halted == 1 || this.initialize_game_run == 0) {
       console.log(`Unable to process future moves now because halted (${this.game.halted}) or gamefeeder not initialized (${this.initialize_game_run})`);
@@ -1516,7 +1512,7 @@ console.log("started queue done");
 
       let ftx = new saito.default.transaction(JSON.parse(this.game.future[i]));
       let ftxmsg = ftx.returnMessage();
-      console.log("FTMSG: " + JSON.stringify(ftxmsg.turn));
+      console.log(`FTMSG (${ftxmsg.step.game}): ` + JSON.stringify(ftxmsg.turn));
 
       if (this.isUnprocessedMove(ftx.transaction.from[0].add, ftxmsg)) {
         //This move (future[i]) is the next one, move it to the queue
@@ -1627,6 +1623,7 @@ console.log("started queue done");
     }
     if (!this.game.accepted.includes(address)){
       this.game.accepted.push(address);
+      this.saveGame(this.game.id);
     }
   }
 

--- a/lib/templates/gametemplate.js
+++ b/lib/templates/gametemplate.js
@@ -516,6 +516,13 @@ class GameTemplate extends ModTemplate {
       //
       if (game_self.initialize_game_run == 0 || game_self.isFutureMove(tx.transaction.from[0].add, txmsg)) {
         game_self.addFutureMove(tx);
+
+        //Safety check in case observer missed a move
+        //If we have multiple moves in the future queue and are receiving moves on chain,
+        //then something has probably gone wrong
+        if (game_self.game.player === 0 && game_self.game.future.length > 3){
+          game_self.observer.controls.next();
+        }
       } else if (game_self.isUnprocessedMove(tx.transaction.from[0].add, txmsg)) {
         game_self.addNextMove(tx);
         if (document[this.hiddenTab]) {


### PR DESCRIPTION
This should fix the 3 person poker fail. It seems the problem was that the players added the observer to their game.accepted but that didn't get saved before a page redirect. Thus, game moves weren't sent to the observing player and queues out of sync. 
Added a secondary safety check for observing players to query the DB if sitting on a long queue of future moves and receiving new moves over the chain.

