### PR TITLE
load saved controls in name check conditional

### DIFF
--- a/mods/quake3/quake3.js
+++ b/mods/quake3/quake3.js
@@ -229,21 +229,18 @@ v	}
   processQuakeLog(logline="", log) {
 
     //
-    // load and apply last saved control scheme
-    //
-    if (logline.indexOf("entered the game") > 0) {
-	this.controls.loadSavedControls();
-	this.controls.writeControls();
-	this.controls.applyControls();
-    }
-
-    //
     // register publickey/name when we enter the game if unset
     //
     if (this.game.player_name_identified == false) {
       if (logline.indexOf("entered the game") > 0) {
         let name = this.app.wallet.returnPublicKey().toLowerCase();
 	this.registerPlayerName();
+	      
+	// load & apply saved controls while here
+	// since this block only happens on client startup
+	this.controls.loadSavedControls();
+	this.controls.writeControls();
+	this.controls.applyControls();
       }
     }
 


### PR DESCRIPTION
Prevents saved controls from execing when other players join as it should only happen when client connects