### PR TITLE
Load open games on reload in arcade

### DIFF
--- a/mods/arcade/arcade.js
+++ b/mods/arcade/arcade.js
@@ -280,6 +280,8 @@ alert("Observer Overlay for URL Games not yet implemented");
             }),
             "open"
           );
+
+          this.app.connection.emit('arcade-invite-manager-render-request');
         }
       }
     );


### PR DESCRIPTION
Issue was that renderInto was rendering invite manager before onPeerHandshake had fetched the open games data from db. so just had to re-render the invite manager after data is fetched.