### PR TITLE
Remove min-width from img overlay

### DIFF
--- a/web/saito/css-imports/saito-image-overlay.css
+++ b/web/saito/css-imports/saito-image-overlay.css
@@ -27,7 +27,6 @@
 }
 
 .saito-overlay-img-cont img {
-  min-width: 50vw;
   max-height: 90vh;
   max-width: 90vw;
 }


### PR DESCRIPTION
**Issue:**
Min-wdith makes imgs looks stretched if img height >>> width


![image](https://user-images.githubusercontent.com/104337801/215321574-4d9220d6-9a8b-4901-9144-078659e4c315.png)
