### PR TITLE
updates to webpack for faster compiles

### DIFF
--- a/compile
+++ b/compile
@@ -268,7 +268,7 @@ if [ "$1" == "nuke" ] || [ "$1" == "init" ]; then
   reset_nonpersistent
   reset_persistent
   reset_bundler
-  node webpack/webpack.prod.cjs $2 $3
+  time node webpack/webpack.config.cjs $2 $3
 
   post_compile
 
@@ -289,7 +289,7 @@ if [ "$1" == "reset" ] || [ "$1" == "dev" ]; then
   reset_nonpersistent
   reset_bundler
 
-  node webpack/webpack.prod.cjs $2 $3
+  time node webpack/webpack.config.cjs $2 $3
 
   post_compile
 
@@ -313,7 +313,7 @@ if [ "$1" == "recompile" ]; then
 
   reset_bundler
 
-  node webpack/webpack.prod.cjs $2 $3
+  time node webpack/webpack.config.cjs $2 $3
 
   post_compile
 

--- a/webpack/webpack.config.cjs
+++ b/webpack/webpack.config.cjs
@@ -1,0 +1,212 @@
+const path = require("path");
+const TerserPlugin = require("terser-webpack-plugin");
+
+const webpack = require("webpack");
+
+let minimize = true;
+let entrypoint = "./../bundler/default/apps/lite/index.ts";
+let outputfile = "saito.js";
+if (process.argv.includes("dev")) {
+  console.log("dev mode source not minified");
+  minimize = false;
+}
+if (process.argv.includes("web3")) {
+  //TODO: build a separate saito.js for web3
+  entrypoint = "./../bundler/default/apps/lite/web3index.ts";
+  outputfile = "web3saito.js";
+}
+webpack({
+ cache: {
+    type: 'filesystem',
+  },
+  optimization: {
+    minimize: minimize,
+    minimizer: [
+      new TerserPlugin({
+        parallel: true,
+      }),
+    ],
+    splitChunks: {
+      chunks: 'async',
+      minSize: 20000,
+      minRemainingSize: 0,
+      minChunks: 1,
+      maxAsyncRequests: 30,
+      maxInitialRequests: 30,
+      enforceSizeThreshold: 50000,
+      cacheGroups: {
+        defaultVendors: {
+          test: /[\\/]node_modules[\\/]/,
+          priority: -10,
+          reuseExistingChunk: true,
+        },
+        default: {
+          minChunks: 2,
+          priority: -20,
+          reuseExistingChunk: true,
+        },
+      },
+    },
+  },
+  target: "web",
+  // node: {
+  //     fs: "empty",
+  // },
+  externals: [
+    {
+      archiver: "archiver"
+    },
+    {
+      child_process: "child_process"
+    },
+    {
+      nodemailer: "nodemailer"
+    },
+    {
+      jimp: "jimp"
+    },
+    {
+      "image-resolve": "image-resolver"
+    },
+    {
+      sqlite: "sqlite"
+    },
+    {
+      unzipper: "unzipper"
+    },
+    {
+      webpack: "webpack",
+
+    },
+    {
+      "node-turn": "node-turn"
+    },
+    // /^(image-resolver|\$)$/i,
+    /\.txt /,
+    /\.png$/,
+    /\.jpg$/,
+    /\.html$/,
+    /\.css$/,
+    /\.sql$/,
+    /\.md$/,
+    /\.pdf$/,
+    /\.sh$/,
+    /\.zip$/,
+    /\/web\//,
+    /\/www\//
+  ],
+  // Path to your entry point. From this file Webpack will begin his work
+  entry: ["babel-polyfill", path.resolve(__dirname, entrypoint)],
+  output: {
+    path: path.resolve(__dirname, "./../web/saito"),
+    filename: outputfile
+  },
+  resolve: {
+    // Add '.ts' and '.tsx' as resolvable extensions.
+    //extensions: ["", ".webpack.js", ".web.js", ".ts", ".tsx", ".js"],
+    extensions: [".webpack.js", ".web.js", ".ts", ".tsx", ".js"],
+    fallback: {
+      "fs": false,
+      "tls": false,
+      "net": false,
+      "path": require.resolve("path-browserify"),
+      "zlib": false,
+      "http": false,
+      "https": false,
+      "stream": require.resolve("stream-browserify"),
+      "buffer": require.resolve("buffer"),
+      "crypto": require.resolve("crypto-browserify"),
+      "crypto-browserify": require.resolve("crypto-browserify"),
+
+    }
+  },
+  module: {
+    rules: [
+      // All files with a '.ts' or '.tsx' extension will be handled by 'ts-loader'.
+      {
+        test: /\.tsx?$/,
+        loader: "ts-loader",
+        exclude: /(node_modules)/
+      },
+      // All output '.js' files will have any sourcemaps re-processed by 'source-map-loader'.
+      {
+        test: /\.js$/,
+        use: [
+          "source-map-loader",
+          {
+            loader: "babel-loader",
+            options: {
+              presets: ["@babel/preset-env"],
+              sourceMaps: false,
+              cacheCompression: false,
+              cacheDirectory: true,
+            }
+          }
+        ],
+        exclude: /(node_modules)/ 
+      },
+      {
+        test: /\.mjs$/,
+        exclude: /(node_modules)/,
+        type: "javascript/auto"
+      },
+      {
+        test: /html$/,
+        exclude: [/(mods)/, /(email)/]
+      },
+      {
+        test: /quirc\.js$/,
+        loader: "exports-loader"
+      },
+      // wasm files should not be processed but just be emitted and we want
+      // to have their public URL.
+      {
+        test: /quirc\.wasm$/,
+        type: "javascript/auto",
+        loader: "file-loader",
+        options: {
+          publicPath: "dist/"
+        }
+      },
+      {
+        test: /\.wasm$/,
+        type: "webassembly/sync",
+      },
+      {
+        test: /\.zip$/,
+        exclude: [
+          path.resolve(__dirname, "../mods/appstore/bundler"),
+          path.resolve(__dirname, "../mods/appstore/mods")
+        ]
+      }
+    ],
+  },
+  plugins: [
+    // Work around for Buffer is undefined:
+    // https://github.com/webpack/changelog-v5/issues/10
+    new webpack.ProvidePlugin({
+      Buffer: ["buffer", "Buffer"]
+    }),
+    new webpack.ProvidePlugin({
+      process: "process/browser"
+    })
+  ],
+  experiments: {
+    asyncWebAssembly: true,
+    syncWebAssembly: true
+  }
+}, (err, stats) => {
+  if (err || stats.hasErrors()) {
+    console.log(err);
+    if (stats) {
+      let info = stats.toJson();
+      console.log(info.errors);
+    }
+  }
+  //
+  // Done processing
+  //
+  console.log("Bundle Success!");
+});
+
+


### PR DESCRIPTION
This change adds caching to the webpack config.

It also changes the webpack config file to webpack.config.js (deprecating webpack.prod.js) - and updates the compile scripts to use the new webpack config.

This change provides massive time improvements on recompiles particulary for small changes (indicative on my machine is 63 seconds -> 5 seconds. Fresh compiles or compiles after adding a module etc are as they were.

A further change is the move away from creating source maps to accompany minified js for dev builds and to simply not minifying the code. (For user experience prod continues to minify code and ship no source maps creating a much smaller payload).

This should also speed up responsiveness of the code in dev (with the console open).

Enjoy.