### PR TITLE
fix(config): Removed post.js from starting default modules

### DIFF
--- a/config/modules.default.js
+++ b/config/modules.default.js
@@ -9,7 +9,7 @@ module.exports = {
     'explorer/explorer.js',
 //    'myqrcode/myqrcode.js',
     'poker/poker.js',
-    'post/post.js',
+    // 'post/post.js',
     'qrscanner/qrscanner.js',
     'relay/relay.js',
     'redsquare/redsquare.js',


### PR DESCRIPTION
When following the README instructions to start a node locally it would fail at `npm run dev` because it couldn't find the post.js module. 
Commented out post.js in the 'core' section of modules.default.js