### PR TITLE
Fix: notification not opening related tweet after click

### DIFF
--- a/mods/redsquare/lib/appspace/home.js
+++ b/mods/redsquare/lib/appspace/home.js
@@ -136,6 +136,8 @@ class AppspaceHome {
     if(thread) {
       window.holder.appendChild(thread);
       this.app.browser.addElementAfterSelector(`<div id="redsquare-appspace-tweet-body" class="redsquare-appspace-body"></div>`, ".redsquare-appspace-header");
+    } else {
+      document.querySelector(".saito-main").innerHTML = `<div id="redsquare-appspace-tweet-body" class="redsquare-appspace-body"></div>`;
     }
 
     tweet.container = ".redsquare-appspace-body";

--- a/mods/redsquare/lib/notification.js
+++ b/mods/redsquare/lib/notification.js
@@ -109,26 +109,28 @@ class RedSquareNotification {
     if (obj) {
       obj.onclick = (e) => {
         let sig = e.currentTarget.getAttribute("data-id");
-	let tweet = this.mod.returnTweet(sig);
-	if (tweet) {
+      	let tweet = this.mod.returnTweet(sig);
+        
+      	if (tweet) {
           app.connection.emit('redsquare-home-tweet-render-request', (tweet));
           app.connection.emit('redsquare-home-loader-render-request');
           mod.loadChildrenOfTweet(sig, (tweets) => {
             app.connection.emit('redsquare-home-loader-hide-request');
-	    for (let i = 0; i < tweets.length; i++) {
+      	    for (let i = 0; i < tweets.length; i++) {
               app.connection.emit('redsquare-home-tweet-append-render-request', (tweets[i]));
-	    }
+      	    }
           });
-	} else {
+      	} else {
           mod.loadTweetWithSig(sig, (tweet) => {
             app.connection.emit('redsquare-home-tweet-render-request', (tweet));
             mod.loadChildrenOfTweet(tweet.tx.transaction.sig, (tweets) => {
-	      for (let i = 0; i < tweets.length; i++) {
+              for (let i = 0; i < tweets.length; i++) {
                 app.connection.emit('redsquare-home-tweet-append-render-request', (tweets[i]));
               }
             });
           });
-	}
+      	}
+      
       }
     }
   }


### PR DESCRIPTION
Explaination:
Was getting this error when clicking on notification

![image](https://user-images.githubusercontent.com/104337801/231776514-0e95077f-e47c-434d-95bd-d314b123e186.png)

scrollIntoView was being added to null tweet div, because tweet div was supposed to be inside appspace-body and appspace-body was missing. Have added appspace-body if its missing.