### PR TITLE
Fix user-menu being empty after theme is changed

### DIFF
--- a/mods/settings/lib/theme-switcher-overlay.js
+++ b/mods/settings/lib/theme-switcher-overlay.js
@@ -28,7 +28,7 @@ class ThemeSwitcherOverlay {
         let theme = e.currentTarget.getAttribute('data-theme');
         if (theme != null) {
           this_self.app.browser.switchTheme(theme);
-          this_self.overlay.hide();
+          this_self.overlay.remove();
         }
       });
 


### PR DESCRIPTION
**Issue:**

![image](https://user-images.githubusercontent.com/104337801/231900817-669e72e7-f8ee-4d77-9df2-3fbc49404827.png)
