### PR TITLE
Make leaderboard header (Rank, Player, Score...) stick

### DIFF
--- a/mods/league/web/css/league-leaderboard.css
+++ b/mods/league/web/css/league-leaderboard.css
@@ -9,7 +9,12 @@
   text-transform: capitalize;
 }
 
-
+.saito-table-header { 
+  position: sticky;
+  top: -1px;
+  background: #3a393c;
+  z-index: 3;
+}
 
 .my-leaderboard-position{
   border: 1px solid var(--saito-primary);
@@ -23,3 +28,6 @@
   content: "\22B3";
   font-size: 1.5rem;
 }
+
+
+


### PR DESCRIPTION
Leaderboard header remains at top of div when scrolling so user can always see what columns represent.