### PR TITLE
Update league-leaderboard.css

### DIFF
--- a/mods/league/web/css/league-leaderboard.css
+++ b/mods/league/web/css/league-leaderboard.css
@@ -12,8 +12,8 @@
 
 .saito-table-header { 
   position: sticky;
-  top: 0px;
-  background: var(--saito-background-light);
+  top: -1px;
+  background: var(--saito-gray-mid);
   z-index: 3;
 }
 


### PR DESCRIPTION
1. fully opaque background to sticky header
2. Moved top up a pixel so scrolled leaderboard doesn't show behind it when filling screen (when window is shrunken).