### PR TITLE
Fix back arrow font color in lite mode

### DIFF
--- a/mods/redsquare/web/css/redsquare-base.css
+++ b/mods/redsquare/web/css/redsquare-base.css
@@ -40,7 +40,7 @@
 
 .redsquare-page-header-title i::before {
   -webkit-text-stroke: unset;
-    color: var(--saito-font-color);
+    color: var(--saito-white);
     margin: 0 0 0 2rem;
 }
 


### PR DESCRIPTION
**Issue:**

![image](https://github.com/SaitoTech/saito-lite-rust/assets/104337801/e7775246-928b-4ceb-8421-1770a24ba923)







**Fix:**
Lite theme
![image](https://github.com/SaitoTech/saito-lite-rust/assets/104337801/cfe3f12e-fa75-4602-8d06-30fe7f8d2f69)




Dark theme
![image](https://github.com/SaitoTech/saito-lite-rust/assets/104337801/ed37e4f0-f0d4-4d6d-b2ec-51ad0579b3b0)
