### PR TITLE
RS: Retweet/Reply overlay changes

### DIFF
--- a/web/saito/css-imports/saito-post.css
+++ b/web/saito/css-imports/saito-post.css
@@ -95,3 +95,10 @@
   margin-right: 0;
 }
 
+
+@media screen and (max-width: 768px) {
+  .post-tweet-preview {
+      display: none;
+  }
+}
+


### PR DESCRIPTION
Hide parent tweet in mobile when replying/retweeting to make room for keyboard in mobile view

**ISSSUE:**

![image](https://github.com/SaitoTech/saito-lite-rust/assets/104337801/7a0508ad-4a68-49f5-aa96-d084862e2dc8)

**SOLUTION:**
![127 0 0 1_12101_redsquare](https://github.com/SaitoTech/saito-lite-rust/assets/104337801/1db6273b-47eb-4dbf-952f-5e4455c26c60)


