### PR TITLE
Custom chat pop resizing

### DIFF
--- a/lib/saito/browser.ts
+++ b/lib/saito/browser.ts
@@ -1262,6 +1262,42 @@ class Browser {
     }
   }
 
+  makeResizeable (target_div, icon_div, unique_id) {
+    let d = document;
+    let target = d.querySelector(target_div);
+    this.addElementToSelector(`<div class="resize-icon" id="resize-icon-${unique_id}"></div>`, icon_div);
+    let pullTab = d.getElementById(`resize-icon-${unique_id}`);
+    let dimensions = target.getBoundingClientRect();
+
+    let ht = dimensions.height; let wd = dimensions.width;
+    let x = 0; let y = 0;
+    let dx = 0; let dy = 0;
+
+    let resize  = (evt) => {
+        dx = evt.screenX - x;
+        dy = evt.screenY - y;
+        x = evt.screenX;
+        y = evt.screenY;
+        wd -= dx;
+        ht -= dy;
+        target.style.width = wd + "px";
+        target.style.height = ht + "px";
+    }
+
+    let resizeFn = resize.bind(this);
+    pullTab.addEventListener("mousedown", (evt) => {
+        x = evt.screenX;
+        y = evt.screenY;
+      
+        d.body.addEventListener("mousemove", resizeFn);
+      
+        d.body.addEventListener("mouseup", () => {
+            d.body.removeEventListener("mousemove", resizeFn);
+        });
+    });
+
+  }
+
   returnAddressHTML(key) {
     return `<div class="saito-address" data-id="${key}">${this.app.keychain.returnIdentifierByPublicKey(
       key,

--- a/mods/chat/lib/chat-manager/popup.js
+++ b/mods/chat/lib/chat-manager/popup.js
@@ -182,6 +182,8 @@ class ChatPopup {
     //
     let popup_id = "chat-popup-" + this.group.id;
     let popup_qs = "#chat-popup-" + this.group.id;
+    let resize_id = "chat-resize-" + this.group.id;
+    let header_qs = "#chat-header-" + this.group.id;
     this_self = this;
 
     let chatPopup = document.querySelector(".chat-container" + popup_qs);
@@ -199,6 +201,7 @@ class ChatPopup {
         // make draggable
         //
         this.app.browser.makeDraggable(popup_id, header_id, true);
+        this.app.browser.makeResizeable(popup_qs, header_qs, group_id);
       }
 
       //

--- a/mods/chat/lib/chat-manager/popup.template.js
+++ b/mods/chat/lib/chat-manager/popup.template.js
@@ -25,26 +25,27 @@ module.exports = (app, mod, group, isStatic = false) => {
   }
 
   let html = `
-      <div class="${class_name} chat-popup" id="chat-popup-${group.id}">
+       <div class="${class_name} chat-popup" id="chat-popup-${group.id}">
 
-        <div class="chat-header" id="chat-header-${group.id}">
-          ${is_encrypted}
-          <div id="chat-group-${group.id}" class="chat-group active-chat-tab saito-address" data-id="${group.name}" data-disable="true">${
-    group.name
-  }</div>
-          <i id="chat-container-close" class="chat-container-close fas fa-times"></i>
-        </div>
+          <div class="chat-header" id="chat-header-${group.id}">
 
-        <div class="chat-body">
-          <div id="load-older-chats" class="saito-chat-button" data-id="${
-            group.id
-          }">fetch earlier messages</div>
-          ${mod.returnChatBody(group.id)}
-        </div>
+            ${is_encrypted}
+            <div id="chat-group-${group.id}" class="chat-group active-chat-tab saito-address" data-id="${group.name}" data-disable="true">${
+      group.name
+    }</div>
+            <i id="chat-container-close" class="chat-container-close fas fa-times"></i>
+          </div>
 
-        <div class="chat-footer">
-          <i class="fa-regular fa-paper-plane chat-input-submit" id="chat-input-submit"></i>
-        </div>
+          <div class="chat-body">
+            <div id="load-older-chats" class="saito-chat-button" data-id="${
+              group.id
+            }">fetch earlier messages</div>
+            ${mod.returnChatBody(group.id)}
+          </div>
+
+          <div class="chat-footer">
+            <i class="fa-regular fa-paper-plane chat-input-submit" id="chat-input-submit"></i>
+          </div>
 
       </div>
   `;

--- a/web/saito/css-imports/saito-chat.css
+++ b/web/saito/css-imports/saito-chat.css
@@ -115,10 +115,10 @@
   background: var(--saito-arcade-background);
   color: var(--saito-font-color);
   max-height: calc(99vh - var(--saito-header-height));
-  overflow: hidden;
-  resize: both;
   min-width: 300px;
   min-height: 150px;
+  overflow-x: hidden;
+  overflow-y: hidden;
 }
 
 .chat-popup {

--- a/web/saito/css-imports/saito-icons.css
+++ b/web/saito/css-imports/saito-icons.css
@@ -5,3 +5,29 @@
   width: 26px;
 }
 
+.resize-icon {
+  position: absolute;
+  left: 0rem;
+  top: -0.2rem;
+  width: 0.8rem;
+  height: 1.3rem;
+  cursor: nw-resize;
+  transform: rotate(45deg);
+  border-right: 1px solid;
+  z-index: 20;
+}
+
+.resize-icon::after {
+  content: "";
+  width: 0.6rem;
+  height: 0.6rem;
+  cursor: nw-resize;
+  border-right: 1px solid;
+  z-index: 21;
+  position: absolute;
+  top: 0rem;
+  left: 0.25rem;
+  top: 0.4rem;
+  width: 0.1rem;
+  height: 0.5rem;
+}


### PR DESCRIPTION
New method `makeResizable()` added to **browser.ts** to make divs resizable by adding resize icon to top-left of div instead of conventional bottom right. 

CSS doesn't allow us to select position of resize icon. By default its position is bottom right. 
There are hacks by doing `transform: rotateZ(180deg)` on outer div and similarly on inner div. But this hack makes docking of chat popup not function properly. 

![image](https://github.com/SaitoTech/saito-lite-rust/assets/104337801/4928fa20-aaea-4180-9c45-50f5b9407b8c)
