### PR TITLE
fixed diagnostic logging

### DIFF
--- a/lib/saito/core/server.ts
+++ b/lib/saito/core/server.ts
@@ -61,7 +61,7 @@ export class NodeSharedMethods extends CustomSharedMethods {
     if (peerData.protocol === "https") {
       protocol = "wss";
     }
-    let url = protocol + "://" + peerData.host + ":" + peerData.port;
+    let url = protocol + "://" + peerData.host + ":" + peerData.port + "/wsopen";
 
     try {
       console.log("connecting to " + url + "....");

--- a/lib/saito/keychain.ts
+++ b/lib/saito/keychain.ts
@@ -146,22 +146,28 @@ class Keychain {
   decryptMessage(publicKey: string, encrypted_msg) {
     // submit JSON parsed object after unencryption
     for (let x = 0; x < this.keys.length; x++) {
-      if (this.keys[x].publicKey === publicKey) {
-        if (this.keys[x].aes_secret) {
-          console.log(encrypted_msg, "------>");
-          const tmpmsg = this.app.crypto.aesDecrypt(encrypted_msg, this.keys[x].aes_secret);
-          if (tmpmsg != null) {
-            console.log(tmpmsg);
-            const tmpx = JSON.parse(tmpmsg);
-            if (tmpx.module != null) {
-              return tmpx;
-            }
-          } 
+      // check for matching public key && see if it has an aes_secret
+      if (this.keys[x].publicKey === publicKey && this.keys[x].aes_secret) {
+        console.log(encrypted_msg, "------>");
+
+        const tmpmsg = this.app.crypto.aesDecrypt(encrypted_msg, this.keys[x].aes_secret);
+        if (tmpmsg == null) {
+          console.log("Failed decryption with aes_secret")
+          return encrypted_msg;
         }
+
+        console.log(tmpmsg);
+
+        const decrypted_msg = JSON.parse(tmpmsg);
+        if (tmpx.module == null) {
+          console.log("Failed to JSON.parse decrypted message")
+          return encrypted_msg;
+        }
+        // Succesful decryption and parsing returns here
+        return decrypted_msg;
       }
     }
     console.log("Key not found, cannot decrypt");
-    // or return original
     return encrypted_msg;
   }
 


### PR DESCRIPTION
The decryption function in keychain should no longer indicate (via logging) that it cannot find the (aes) key when it can.

Added specific logging messages for each failure case.

https://github.com/SaitoTech/saito-lite-rust/issues/2218#issue-2033717216