### PR TITLE
graffiti: split large db statements

### DIFF
--- a/mods/place/lib/place-ui.js
+++ b/mods/place/lib/place-ui.js
@@ -819,6 +819,12 @@ class PlaceUI {
     return zoomFactor;
   }
 
+  updateTilesRendering(locatedStateArray) {
+    for (const locatedState of locatedStateArray) {
+      this.updateTileRendering(locatedState);
+    }
+  }
+
   updateTileRendering(newLocatedState) {
     const {i: i, j: j, state: newState} = newLocatedState;
     if (newState.drafted !== null) {


### PR DESCRIPTION
Updating a large number of tiles in the database requires splitting the operation into several statements, in accordance with SQLite's limit of 999 values per statement.