### PR TITLE
Fix chat getting stuck on community chats

### DIFF
--- a/mods/chat/chat.js
+++ b/mods/chat/chat.js
@@ -114,7 +114,8 @@ class Chat extends ModTemplate {
 		if (app.BROWSER == 0) {
 			this.communityGroup = this.returnOrCreateChatGroupFromMembers(
 				[this.publicKey],
-				this.communityGroupName
+				this.communityGroupName,
+				true
 			);
 			this.communityGroup.members = [this.publicKey];
 
@@ -1512,7 +1513,8 @@ class Chat extends ModTemplate {
 	returnOrCreateChatGroupFromMembers(
 		members = null,
 		name = null,
-		update_name = true
+		update_name = true,
+		isCommunity = false
 	) {
 		if (!members) {
 			return null;
@@ -1523,6 +1525,7 @@ class Chat extends ModTemplate {
 		//This might keep persistence across server resets
 		if (name === this.communityGroupName) {
 			id = this.app.crypto.hash(this.communityGroupName);
+			isCommunity = true;
 		} else {
 			//Make sure that I am part of the chat group
 			if (!members.includes(this.publicKey)) {
@@ -1571,7 +1574,8 @@ class Chat extends ModTemplate {
 			name: name,
 			txs: [],
 			unread: 0,
-			last_update: 0
+			last_update: 0,
+			community: isCommunity
 		};
 
 		//Prepend the community chat

--- a/mods/chat/lib/chat-manager/popup.js
+++ b/mods/chat/lib/chat-manager/popup.js
@@ -69,6 +69,7 @@ class ChatPopup {
 		//
 		// exit if group unset
 		//
+
 		if (this.group == null) {
 			return;
 		}
@@ -103,6 +104,7 @@ class ChatPopup {
 				this.input.display = 'small';
 			}
 		}
+
 
 		//
 		// calculate some values to determine position on screen...
@@ -205,7 +207,7 @@ class ChatPopup {
 
 		// add call icon, ignore if community chat
 		let mods = this.app.modules.mods;
-		if (this.group.name != this.mod.communityGroupName) {
+    if (!this.group.community) {
 			let index = 0;
 			for (const mod of mods) {
 				let item = mod.respondTo('chat-actions', {

--- a/mods/stun/lib/components/call-interface-video.js
+++ b/mods/stun/lib/components/call-interface-video.js
@@ -223,7 +223,8 @@ class CallInterfaceVideo {
 			members: [peer],
 			name: `Video Chat`,
 			txs: [],
-			unread: 0
+			unread: 0,
+			community: true
 			//
 			// USE A TARGET Container if the chat box is supposed to show up embedded within the UI
 			// Don't include if you want it to be just a chat popup....


### PR DESCRIPTION
**Issue:** 
Chat in videocall was getting stuck because call icon wasn't getting added properly and thus events werent getting attached. We had check for "Saito Community Chat" but no check for other community groups.

**Solution:**
Introduced a new parameter "community" to chat groups. And using this parameter identifying whether a chat is for community or not. If its community chat then skip adding call icon.