### PR TITLE
Feature/chat groups

### DIFF
--- a/lib/saito/ui/game-menu/game-menu.js
+++ b/lib/saito/ui/game-menu/game-menu.js
@@ -689,12 +689,25 @@ class GameMenu {
 			}
 		);
 
+
 		menu_self.addMenuOption('game-social', 'Chat');
 
 		//
 		// Create group chat but just for this game, not the whole community
 		//
 		if (this.game_mod?.game?.players?.length > 1) {
+
+			this.app.connection.on('chat-ready', ()=> {
+				this.app.connection.emit('open-chat-with', {
+					key: this.game_mod.game.players.slice(),
+					name: this.game_mod.returnName() + ' Chat',
+					id: this.game_mod.game.id
+				});
+
+				this.app.connection.emit('chat-manager-request-no-interrupts');
+
+			});
+
 			menu_self.addSubMenuOption('game-social', {
 				text: 'Player Chat',
 				id: 'game-chat-group',
@@ -715,6 +728,8 @@ class GameMenu {
 							key: game_mod.game.opponents[0]
 						});
 					}
+
+					this.app.connection.emit('chat-manager-request-no-interrupts');
 				}
 			});
 		}

--- a/lib/saito/ui/modals/saito-contacts/saito-contacts.js
+++ b/lib/saito/ui/modals/saito-contacts/saito-contacts.js
@@ -57,6 +57,7 @@ class SaitoContacts {
 							}
 						});
 					if (this.callback) {
+						console.log("Run Call back on selected", selected);
 						this.callback(selected);
 					}
 					this.overlay.remove();

--- a/lib/saito/ui/modals/saito-contacts/saito-contacts.template.js
+++ b/lib/saito/ui/modals/saito-contacts/saito-contacts.template.js
@@ -35,7 +35,6 @@ module.exports = (app, contacts, keylist = null) => {
 
 
   if (keylist){
-  	console.log("Use keylist");
   	for (let publicKey of keylist){
 
   		let key = app.keychain.returnKey(publicKey, true);
@@ -45,7 +44,6 @@ module.exports = (app, contacts, keylist = null) => {
   }else{
 		let keys = app.keychain.returnKeys();
 
-		console.log(keys);
 		for (let i = 0; i < keys.length; i++) {
 			let publicKey = keys[i].publicKey;
 			html += userTemplate(publicKey, keys[i]?.aes_publicKey);

--- a/lib/saito/ui/modals/user-menu/user-menu.js
+++ b/lib/saito/ui/modals/user-menu/user-menu.js
@@ -77,7 +77,7 @@ class UserMenu {
 		let thisobj = this;
 		let pk = this.user_publickey;
 		document
-			.querySelectorAll('.saito-modal-menu-option')
+			.querySelectorAll('#saito-user-menu .saito-modal-menu-option')
 			.forEach((menu) => {
 				let id = menu.getAttribute('id');
 				let callback = thisobj.callbacks[id];
@@ -89,7 +89,7 @@ class UserMenu {
 	}
 
 	addMenuItem(item, id) {
-		document.querySelector('.saito-modal-content').innerHTML += `
+		document.querySelector('#saito-user-menu .saito-modal-content').innerHTML += `
           <div id="${id}" class="saito-modal-menu-option"><i class="${item.icon}"></i><div>${item.text}</div></div>
         `;
 	}

--- a/lib/saito/ui/saito-profile/saito-profile.template.js
+++ b/lib/saito/ui/saito-profile/saito-profile.template.js
@@ -45,7 +45,8 @@ module.exports = SaitoProfileTemplate = (app, mod, profile) => {
         </div>  
       </div>
      <div class="saito-profile-info">
-      <div class="saito-username">${profile.publicKey}</div>`;
+      <div class="saito-username">${profile.publicKey}</div>
+    </div>`;
 
 	html += `
     <div class="saito-profile-menu">
@@ -72,8 +73,7 @@ module.exports = SaitoProfileTemplate = (app, mod, profile) => {
     </div>
   `;
 
-	html += `</div>
-    </div>`;
+	html += `</div>`;
 
 	return html;
 };

--- a/mods/chat/chat.js
+++ b/mods/chat/chat.js
@@ -10,7 +10,7 @@ const localforage = require('localforage');
 const Transaction = require('../../lib/saito/transaction').default;
 const PeerService = require('saito-js/lib/peer_service').default;
 const ChatSettings = require('./lib/overlays/chat-manager-menu');
-const ChatSidebar = require("./lib/appspace/chat-sidebar");
+const ChatSidebar = require('./lib/appspace/chat-sidebar');
 
 class Chat extends ModTemplate {
 	constructor(app) {
@@ -49,7 +49,7 @@ class Chat extends ModTemplate {
 		this.communityGroup = null;
 		this.communityGroupName = 'Saito Community Chat';
 
-		this.debug = false;
+		this.debug = true;
 
 		this.chat_manager = null;
 
@@ -88,9 +88,10 @@ class Chat extends ModTemplate {
 			}
 		);
 
-		this.app.connection.on("chat-ready", ()=> {
-			if (this.auto_open_community){
-				this.app.connection.emit("chat-popup-render-request");
+		this.app.connection.on('chat-ready', () => {
+			if (this.auto_open_community) {
+				this.app.connection.emit('chat-popup-render-request');
+				this.app.connection.emit("chat-manager-opens-group", this.communityGroup);
 			}
 		});
 
@@ -102,7 +103,6 @@ class Chat extends ModTemplate {
 
 			let newtx = await this.createChatTransaction(group.id, message);
 			await this.sendChatTransaction(this.app, newtx);
-
 		});
 
 		this.postScripts = ['/saito/lib/emoji-picker/emoji-picker.js'];
@@ -116,11 +116,11 @@ class Chat extends ModTemplate {
 		this.orig_title = '';
 	}
 
-	hasSettings(){
+	hasSettings() {
 		return true;
 	}
 
-	loadSettings(container){
+	loadSettings(container) {
 		let as = new ChatSettings(this.app, this, container);
 		as.render();
 	}
@@ -238,11 +238,53 @@ class Chat extends ModTemplate {
 
 		await super.render();
 
+		let chat_id = this.app.browser.returnURLParameter('chat_id');
 
-		if (this.app.browser.returnURLParameter('chat_id')){
-			this.app.connection.emit("open-chat-with", {
-				key: this.app.browser.returnURLParameter('chat_id')
-			});
+		if (chat_id) {
+			if (this.app.crypto.isPublicKey(chat_id)) {
+				//data.key = public key(s) of other chat parties
+				this.app.connection.emit('open-chat-with', { key: chat_id });
+			} else {
+				let chat_group = JSON.parse(
+					this.app.crypto.base64ToString(chat_id)
+				);
+				let search = this.returnGroup(chat_group.id);
+				if (search) {
+					//data.id = group id
+					this.app.connection.emit('open-chat-with', {
+						id: chat_group.id
+					});
+				} else {
+					// To do -- add here
+
+					chat_group.members = [];
+					chat_group.txs = [];
+					chat_group.unread = 0;
+					chat_group.last_update = 0;
+
+					for (let i in chat_group.member_ids){
+						if (chat_group.member_ids[i] !== -1){
+							chat_group.members.push(i);
+						}
+					}
+
+					chat_group.members.push(this.publicKey);
+					chat_group.member_ids[this.publicKey] = 1;
+
+					this.groups.push(chat_group);
+
+					this.saveChatGroup(chat_group);
+
+					this.app.connection.emit('chat-manager-render-request');
+				}
+
+				this.sendJoinGroupTransaction(chat_group);
+				this.app.connection.emit("chat-manager-opens-group", chat_group);
+	
+			}
+		
+
+			window.history.pushState({}, document.title, "/" + this.slug);
 		}
 	}
 
@@ -308,7 +350,8 @@ class Chat extends ModTemplate {
 			);
 			this.communityGroup.members = [peer.publicKey];
 
-			this.communityGroup.description = "an open forum for anyone on Saito to chat";
+			this.communityGroup.description =
+				'an open forum for anyone on Saito to chat';
 
 			if (this.communityGroup) {
 				//
@@ -384,8 +427,8 @@ class Chat extends ModTemplate {
 								);
 								return;
 							}
-						
-							this.app.connection.emit("chat-ready");
+
+							this.app.connection.emit('chat-ready');
 						}
 					}
 				);
@@ -409,144 +452,114 @@ class Chat extends ModTemplate {
 		let force = false;
 
 		switch (type) {
-		case 'chat-manager':
-			if (this.chat_manager == null) {
-				this.chat_manager = new ChatManager(this.app, this);
-			}
-			return this.chat_manager;
-		case 'saito-game-menu':
-			// Need to make sure this is created so we can listen for requests to open chat popups
-			if (this.chat_manager == null) {
-				this.chat_manager = new ChatManager(this.app, this);
-			}
-			// Toggle this so that we can have the in-game menu launch a floating overlay for the chat manager
-			force = true;
+			case 'chat-manager':
+				if (this.chat_manager == null) {
+					this.chat_manager = new ChatManager(this.app, this);
+				}
+				return this.chat_manager;
+			case 'saito-game-menu':
+				// Need to make sure this is created so we can listen for requests to open chat popups
+				if (this.chat_manager == null) {
+					this.chat_manager = new ChatManager(this.app, this);
+				}
+				// Toggle this so that we can have the in-game menu launch a floating overlay for the chat manager
+				force = true;
 
-		case 'saito-header':
-		case 'saito-floating-menu':
-			//
-			// In mobile, we use the hamburger menu to open chat (without leaving the page)
-			//
-			if (
-				this.app.browser.isMobileBrowser() ||
+			case 'saito-header':
+			case 'saito-floating-menu':
+				//
+				// In mobile, we use the hamburger menu to open chat (without leaving the page)
+				//
+				if (
+					this.app.browser.isMobileBrowser() ||
 					(this.app.BROWSER && window.innerWidth < 600) ||
 					force
-			) {
-				if (this.chat_manger) {
-					//Don't want mobile chat auto popping up
-					this.chat_manager.render_popups_to_screen = 0;
-				}
+				) {
+					if (this.chat_manger) {
+						//Don't want mobile chat auto popping up
+						this.chat_manager.render_popups_to_screen = 0;
+					}
 
-				if (this.chat_manager_overlay == null) {
-					this.chat_manager_overlay = new ChatManagerOverlay(
-						this.app,
-						this
-					);
-				}
-				return [
-					{
-						text: 'Chat',
-						icon: 'fas fa-comments',
-						callback: function (app, id) {
-							console.log('Render Chat manager overlay');
-							chat_self.chat_manager_overlay.render();
-						},
-						event: function (id) {
-							chat_self.app.connection.on(
-								'chat-manager-render-request',
-								() => {
-									let elem = document.getElementById(id);
-									//console.log("Chat event, update", elem);
-									if (elem) {
-										let unread = 0;
-										for (let group of chat_self.groups) {
-											unread += group.unread;
-										}
-
-										if (unread) {
-											if (
-												elem.querySelector(
-													'.saito-notification-dot'
-												)
-											) {
-												elem.querySelector(
-													'.saito-notification-dot'
-												).innerHTML = unread;
-											} else {
-												chat_self.app.browser.addElementToId(
-													`<div class="saito-notification-dot">${unread}</div>`,
-													id
-												);
+					if (this.chat_manager_overlay == null) {
+						this.chat_manager_overlay = new ChatManagerOverlay(
+							this.app,
+							this
+						);
+					}
+					return [
+						{
+							text: 'Chat',
+							icon: 'fas fa-comments',
+							callback: function (app, id) {
+								console.log('Render Chat manager overlay');
+								chat_self.chat_manager_overlay.render();
+							},
+							event: function (id) {
+								chat_self.app.connection.on(
+									'chat-manager-render-request',
+									() => {
+										let elem = document.getElementById(id);
+										//console.log("Chat event, update", elem);
+										if (elem) {
+											let unread = 0;
+											for (let group of chat_self.groups) {
+												unread += group.unread;
 											}
-										} else {
-											if (
-												elem.querySelector(
-													'.saito-notification-dot'
-												)
-											) {
-												elem.querySelector(
-													'.saito-notification-dot'
-												).remove();
+
+											if (unread) {
+												if (
+													elem.querySelector(
+														'.saito-notification-dot'
+													)
+												) {
+													elem.querySelector(
+														'.saito-notification-dot'
+													).innerHTML = unread;
+												} else {
+													chat_self.app.browser.addElementToId(
+														`<div class="saito-notification-dot">${unread}</div>`,
+														id
+													);
+												}
+											} else {
+												if (
+													elem.querySelector(
+														'.saito-notification-dot'
+													)
+												) {
+													elem.querySelector(
+														'.saito-notification-dot'
+													).remove();
+												}
 											}
 										}
 									}
-								}
-							);
+								);
 
-							//Trigger my initial display
-							chat_self.app.connection.emit(
-								'chat-manager-render-request'
-							);
+								//Trigger my initial display
+								chat_self.app.connection.emit(
+									'chat-manager-render-request'
+								);
+							}
 						}
-					}
-				];
-			} else if (!chat_self.browser_active) {
-				//
-				// Otherwise we go to the main chat application
-				//
-				return [
-					{
-						text: 'Chat',
-						icon: 'fas fa-comments',
-						callback: function (app, id) {
-							window.location = '/chat';
+					];
+				} else if (!chat_self.browser_active) {
+					//
+					// Otherwise we go to the main chat application
+					//
+					return [
+						{
+							text: 'Chat',
+							icon: 'fas fa-comments',
+							callback: function (app, id) {
+								window.location = '/chat';
+							}
 						}
-					}
-				];
-			}
-			return null;
-		case 'user-menu':
-			if (obj?.publicKey !== this.publicKey) {
-				return {
-					text: 'Chat',
-					icon: 'far fa-comment-dots',
-					callback: function (app, publicKey) {
-						if (chat_self.chat_manager == null) {
-							chat_self.chat_manager = new ChatManager(
-								chat_self.app,
-								chat_self
-							);
-						}
-
-						chat_self.chat_manager.render_popups_to_screen = 1;
-						chat_self.app.connection.emit('open-chat-with', {
-							key: publicKey
-						});
-					}
-				};
-			}
-
-			return null;
-
-		//
-		// Abandoned code to duplicate user menu in saito-profile
-		//
-		case 'saito-profile-menu':
-			if (obj?.publicKey) {
-				if (
-					chat_self.app.keychain.hasPublicKey(obj.publicKey) &&
-						obj.publicKey !== this.publicKey
-				) {
+					];
+				}
+				return null;
+			case 'user-menu':
+				if (obj?.publicKey !== this.publicKey) {
 					return {
 						text: 'Chat',
 						icon: 'far fa-comment-dots',
@@ -559,18 +572,48 @@ class Chat extends ModTemplate {
 							}
 
 							chat_self.chat_manager.render_popups_to_screen = 1;
-							chat_self.app.connection.emit(
-								'open-chat-with',
-								{ key: publicKey }
-							);
+							chat_self.app.connection.emit('open-chat-with', {
+								key: publicKey
+							});
 						}
 					};
 				}
-			}
 
-			return null;
-		default:
-			return super.respondTo(type);
+				return null;
+
+			//
+			// Abandoned code to duplicate user menu in saito-profile
+			//
+			case 'saito-profile-menu':
+				if (obj?.publicKey) {
+					if (
+						chat_self.app.keychain.hasPublicKey(obj.publicKey) &&
+						obj.publicKey !== this.publicKey
+					) {
+						return {
+							text: 'Chat',
+							icon: 'far fa-comment-dots',
+							callback: function (app, publicKey) {
+								if (chat_self.chat_manager == null) {
+									chat_self.chat_manager = new ChatManager(
+										chat_self.app,
+										chat_self
+									);
+								}
+
+								chat_self.chat_manager.render_popups_to_screen = 1;
+								chat_self.app.connection.emit(
+									'open-chat-with',
+									{ key: publicKey }
+								);
+							}
+						};
+					}
+				}
+
+				return null;
+			default:
+				return super.respondTo(type);
 		}
 	}
 
@@ -586,8 +629,12 @@ class Chat extends ModTemplate {
 
 			let txmsg = tx.returnMessage();
 
+			if (!txmsg.module == "Chat"){
+				return;
+			}
+
 			if (this.debug) {
-				//console.log("Chat onConfirmation: " + txmsg.request);
+				console.log("Chat onConfirmation: " + txmsg.request);
 			}
 
 			if (txmsg.request == 'chat message') {
@@ -599,8 +646,8 @@ class Chat extends ModTemplate {
 			if (txmsg.request == 'chat join') {
 				await this.receiveJoinGroupTransaction(tx);
 			}
-			if (txmsg.request == 'chat add') {
-				await this.receiveAddMemberTransaction(tx);
+			if (txmsg.request == 'chat update') {
+				await this.receiveUpdateGroupTransaction(tx);
 			}
 			if (txmsg.request == 'chat remove') {
 				await this.receiveRemoveMemberTransaction(tx);
@@ -638,7 +685,7 @@ class Chat extends ModTemplate {
 			let group = this.returnGroup(txmsg?.data?.group_id);
 
 			if (!group) {
-				console.log('Group doesn\'t exist?');
+				console.log("Group doesn't exist?");
 				return 0;
 			}
 
@@ -680,6 +727,15 @@ class Chat extends ModTemplate {
 			return;
 		}
 
+		if (txmsg.request == 'chat update') {
+			this.receiveUpdateGroupTransaction(tx);
+			return;
+		}
+
+		if (txmsg.request == 'chat remove') {
+			this.receiveRemoveMemberTransaction(tx);
+			return;
+		}
 
 		if (txmsg.request === 'chat message broadcast') {
 			let inner_tx = new Transaction(undefined, txmsg.data);
@@ -760,7 +816,7 @@ class Chat extends ModTemplate {
 			module: 'Chat',
 			request: 'chat group',
 			name: name,
-			admin: this.publicKey,
+			admin: this.publicKey
 		};
 
 		console.log(newtx.msg);
@@ -769,18 +825,16 @@ class Chat extends ModTemplate {
 
 		await this.app.network.propagateTransaction(newtx);
 
-		this.app.connection.emit("relay-transaction", newtx);
+		this.app.connection.emit('relay-transaction', newtx);
 	}
 
 	async receiveCreateGroupTransaction(tx) {
-
-		console.log("Receiving group creation tx");
+		console.log('Receiving group creation tx');
 
 		if (tx.isTo(this.publicKey)) {
 			let txmsg = tx.returnMessage();
 
-			if (this.returnGroup(tx.signature)){
-				console.warn("Already have this group!");
+			if (this.returnGroup(tx.signature)) {
 				return;
 			}
 
@@ -802,7 +856,7 @@ class Chat extends ModTemplate {
 			}
 
 			newGroup.member_ids[this.publicKey] = 1;
-			newGroup.member_ids[txmsg.admin] = "admin";
+			newGroup.member_ids[txmsg.admin] = 'admin';
 
 			this.groups.push(newGroup);
 
@@ -812,6 +866,10 @@ class Chat extends ModTemplate {
 
 			if (!tx.isFrom(this.publicKey)) {
 				await this.sendJoinGroupTransaction(newGroup);
+			} else {
+				// We have now generated a unique ID (transaction signature) for the chat group
+				// and can create a link for anyone else to find it
+				this.generateChatGroupLink(newGroup);
 			}
 		}
 	}
@@ -821,41 +879,46 @@ class Chat extends ModTemplate {
 	// But in the future, we may add a confirmation interface
 	//
 	async sendJoinGroupTransaction(group) {
-
-		let newtx = await this.app.wallet.createUnsignedTransactionWithDefaultFee();
+		let newtx =
+			await this.app.wallet.createUnsignedTransactionWithDefaultFee(this.publicKey);
 
 		if (!newtx) {
 			return;
 		}
 
-		for (let i = 0; i < group.members.length; i++) {
-			if (group.members[i] !== this.publicKey) {
-				newtx.addTo(group.members[i]);
+		for (let i in group.member_ids) {
+			if (i !== this.publicKey) {
+				newtx.addTo(i);
 			}
 		}
 
 		newtx.msg = {
 			module: 'Chat',
 			request: 'chat join',
-			group_id: group.id,
+			group_id: group.id
 		};
 
 		await newtx.sign();
 
 		await this.app.network.propagateTransaction(newtx);
-		this.app.connection.emit("relay-transaction", newtx);
-
+		this.app.connection.emit('relay-transaction', newtx);
 	}
 
 	async receiveJoinGroupTransaction(tx) {
 		if (tx.isTo(this.publicKey)) {
-
 			let txmsg = tx.returnMessage();
 
 			let group = this.returnGroup(txmsg.group_id);
 
 			if (!group) {
-				console.warn("Receiving chat group transaction from a group I don't know");
+				console.warn(
+					"Receiving chat group transaction from a group I don't know"
+				);
+				return;
+			}
+
+			if (group.member_ids[tx.from[0].publicKey] == -1) {
+				console.log('Blacklisted member attempting to rejoin!');
 				return;
 			}
 
@@ -869,13 +932,17 @@ class Chat extends ModTemplate {
 			}
 
 			this.saveChatGroup(group);
+		
+			if (group.member_ids[this.publicKey] == "admin"){
+				this.sendUpdateGroupTransaction(group, tx.from[0].publicKey);
+			}
 		}
 	}
 
 	//
-	// Add a member to an existing chat group
+	// 
 	//
-	async sendAddMemberTransaction(group, member) {
+	async sendUpdateGroupTransaction(group, target = null) {
 		let newtx = await this.app.wallet.createUnsignedTransaction(
 			this.publicKey,
 			BigInt(0),
@@ -885,43 +952,33 @@ class Chat extends ModTemplate {
 			return;
 		}
 
-		if (!group.members.includes(member)) {
-			group.members.push(member);
-		}
-
-		for (let i = 0; i < group.members.length; i++) {
-			if (group.members[i] !== this.publicKey) {
-				newtx.addTo(group.members[i]);
+		if (target){
+			newtx.addTo(target);
+		}else{
+			for (let i = 0; i < group.members.length; i++) {
+				if (group.members[i] !== this.publicKey) {
+					newtx.addTo(group.members[i]);
+				}
 			}
 		}
 
 		newtx.msg = {
 			module: 'Chat',
-			request: 'chat add',
+			request: 'chat update',
 			group_name: group.name,
 			group_id: group.id,
-			member_id: member
+			member_ids: group.member_ids,
 		};
 
 		await newtx.sign();
 
 		await this.app.network.propagateTransaction(newtx);
+		this.app.connection.emit('relay-transaction', newtx);
 	}
 
-	async receiveAddMemberTransaction(tx) {
+	async receiveUpdateGroupTransaction(tx) {
 		if (tx.isTo(this.publicKey)) {
 			let txmsg = tx.returnMessage();
-
-			//I am receiving message about being added to the group
-			if (this.publicKey == txmsg.member_id) {
-				await this.receiveCreateGroupTransaction(tx);
-				let group = this.returnGroup(txmsg.group_id);
-
-				tx.msg.message = `<div class="saito-chat-notice">added you to the group</div>`;
-				this.addTransactionToGroup(group, tx);
-
-				return;
-			}
 
 			let group = this.returnGroup(txmsg.group_id);
 
@@ -930,27 +987,54 @@ class Chat extends ModTemplate {
 				return;
 			}
 
-			if (!group.members.includes(txmsg.member_id)) {
-				group.members.push(txmsg.member_id);
+			let sender = tx.from[0].publicKey;
+
+			if (group.member_ids[sender] !== "admin"){
+				console.log("Non-admin attempting to change the group!");
+				return;
 			}
 
-			//
-			//Don't overwrite confirmed flag if txs arrive out of order
-			//
-			if (!group.member_ids) {
-				group.member_ids = {};
+			tx.msg.message = "";
+
+			if (txmsg.group_name !== group.name){
+				tx.msg.message += `<div class="saito-chat-notice">changed the name of the group to ${txmsg.group_name}</div>`;
+				group.name = txmsg.group_name;
 			}
 
-			if (!group.member_ids[txmsg.member_id]) {
-				group.member_ids[txmsg.member_id] = 0;
+			for (let i in txmsg.member_ids){
+				let add_member = 0;
+				if (txmsg.member_ids[i] !== group.member_ids[i]){
+					if (txmsg.member_ids[i] == "admin"){
+						group.member_ids[i] = "admin";
+						tx.msg.message += `<div class="saito-chat-notice">granted admin rights to ${this.app.browser.returnAddressHTML(i)}</div>`;
+						add_member = 1;
+					}
+					if (txmsg.member_ids[i] == 1) {
+						add_member = 1;	
+					}
+					if (txmsg.member_ids[i] == -1) {
+						add_member = -1;
+					}
+
+					if (add_member){
+						group.member_ids[i] = txmsg.member_ids[i];
+						if (add_member > 0 && !group.members.includes(i)){
+							group.members.push(i);
+						}else if (add_member < 0 && group.members.includes(i)){
+							for (let j = 0; j < group.members.length; j++){
+								if (group.members[j] == i){
+									group.members.splice(j, 1);
+									break;
+								}
+							}
+						}
+					}
+				}
 			}
 
-			tx.msg.message = `<div class="saito-chat-notice">added ${this.app.browser.returnAddressHTML(
-				txmsg.member_id
-			)} to the group</div>`;
 			this.addTransactionToGroup(group, tx);
 
-			//      this.saveChatGroup(group);
+			this.saveChatGroup(group);
 		}
 	}
 
@@ -980,6 +1064,7 @@ class Chat extends ModTemplate {
 		await newtx.sign();
 
 		await this.app.network.propagateTransaction(newtx);
+		this.app.connection.emit('relay-transaction', newtx);
 	}
 
 	async receiveRemoveMemberTransaction(tx) {
@@ -989,33 +1074,38 @@ class Chat extends ModTemplate {
 			let group = this.returnGroup(txmsg.group_id);
 
 			if (!group) {
-				console.warn('Chat group doesn\'t exist locally');
+				console.warn(`Chat group doesn't exist locally`);
 				return;
 			}
 
-			for (let i = 0; i < group.members.length; i++) {
-				if (group.members[i] == txmsg.member_id) {
-					group.members.splice(i, 1);
-					break;
+			let sender = tx.from[0].publicKey;
+
+			if (
+				group.member_ids[sender] == 'admin' ||
+				sender == txmsg.member_id
+			) {
+				for (let i = 0; i < group.members.length; i++) {
+					if (group.members[i] == txmsg.member_id) {
+						group.members.splice(i, 1);
+						break;
+					}
 				}
-			}
 
-			if (group.member_ids) {
-				delete group.member_ids[txmsg.member_id];
-			}
-
-			if (this.publicKey == txmsg.member_id) {
-				await this.deleteChatGroup(group);
-			} else {
-				if (tx.isFrom(txmsg.member_id)) {
-					tx.msg.message = `<div class="saito-chat-notice">left the group</div>`;
+				if (this.publicKey == txmsg.member_id) {
+					await this.deleteChatGroup(group);
 				} else {
-					tx.msg.message = `<div class="saito-chat-notice">kicked ${this.app.browser.returnAddressHTML(
-						txmsg.member_id
-					)} out of the group</div>`;
-				}
+					if (tx.isFrom(txmsg.member_id)) {
+						group.member_ids[txmsg.member_id] = 0;
+						tx.msg.message = `<div class="saito-chat-notice">left the group</div>`;
+					} else {
+						group.member_ids[txmsg.member_id] = -1;
+						tx.msg.message = `<div class="saito-chat-notice">kicked ${this.app.browser.returnAddressHTML(
+							txmsg.member_id
+						)} out of the group</div>`;
+					}
 
-				this.addTransactionToGroup(group, tx);
+					this.addTransactionToGroup(group, tx);
+				}
 			}
 		}
 	}
@@ -1131,7 +1221,7 @@ class Chat extends ModTemplate {
 			}
 		}
 
-		if (members.length == 2) {
+		if (members.length == 2 && !group?.member_ids) {
 			console.log('Chat: Try encrypting Message for ' + secret_holder);
 
 			//
@@ -1172,9 +1262,9 @@ class Chat extends ModTemplate {
 			console.log(JSON.parse(JSON.stringify(txmsg)));
 		}
 
-		for (let blocked of this.black_list){
-			if (tx.isFrom(blocked)){
-				console.log("Refuse chat message from blocked account");
+		for (let blocked of this.black_list) {
+			if (tx.isFrom(blocked)) {
+				console.log('Refuse chat message from blocked account');
 				return;
 			}
 		}
@@ -1274,8 +1364,8 @@ class Chat extends ModTemplate {
 
 						const replyButton = `
               <div data-id="${block[z].signature}" data-href="${
-	sender + ts
-}" class="saito-userline-reply">
+							sender + ts
+						}" class="saito-userline-reply">
                 <div class="chat-copy"><i class="fas fa-copy"></i></div>
                 <div class="chat-reply"><i class="fas fa-reply"></i></div>
                 <div class="saito-chat-line-controls">
@@ -1292,7 +1382,10 @@ class Chat extends ModTemplate {
 								: ''
 						}">`;
 						if (block[z].msg.indexOf('<img') != 0) {
-							msg += this.app.browser.sanitize(block[z].msg, true);
+							msg += this.app.browser.sanitize(
+								block[z].msg,
+								true
+							);
 						} else {
 							msg += block[z].msg.substring(
 								0,
@@ -1316,7 +1409,7 @@ class Chat extends ModTemplate {
 			}
 		}
 
-		if (!html){
+		if (!html) {
 			html = `<div class="saito-time-stamp">say hello</div>`;
 		}
 
@@ -1368,8 +1461,8 @@ class Chat extends ModTemplate {
 			last = next;
 		}
 
-		if (block.length > 0){
-			blocks.push(block);	
+		if (block.length > 0) {
+			blocks.push(block);
 		}
 
 		return blocks;
@@ -1634,7 +1727,20 @@ class Chat extends ModTemplate {
 	returnMembers(group_id) {
 		for (let i = 0; i < this.groups.length; i++) {
 			if (group_id === this.groups[i].id) {
-				return [...new Set(this.groups[i].members)];
+				if (this.groups[i].member_ids){
+					let members = [];
+					for (let m of this.groups[i].members){
+						if (!members.includes(m)){
+							if (this.groups[i].member_ids[m] == "admin" || this.groups[i].member_ids[m] == 1){
+								members.push(m);
+							}	
+						}
+						
+					}
+					return members;
+				} else{
+					return [...new Set(this.groups[i].members)];	
+				}
 			}
 		}
 		return [];
@@ -1741,25 +1847,27 @@ class Chat extends ModTemplate {
 	///////////////////
 	// LOCAL STORAGE //
 	///////////////////
-	loadOptions(){
-
+	loadOptions() {
 		//Enforce compliance with wallet indexing
 		if (!this.app.options?.chat) {
 			this.app.options.chat = {};
 			this.app.options.chat.groups = [];
 		} else if (Array.isArray(this.app.options.chat)) {
 			let newObj = {
-				groups: this.app.options.chat,
+				groups: this.app.options.chat
 			};
 			this.app.options.chat = newObj;
 		} else {
 			//
 			//These default to false, so will only toggle on if a true value is stored in options
 			//
-			this.enable_notifications = this.app.options.chat?.enable_notifications;
-			this.audio_notifications = this.app.options.chat?.audio_notifications;
-			this.auto_open_community = this.app.options.chat?.auto_open_community;
-			if (this.app.options.chat?.black_list){
+			this.enable_notifications =
+				this.app.options.chat?.enable_notifications;
+			this.audio_notifications =
+				this.app.options.chat?.audio_notifications;
+			this.auto_open_community =
+				this.app.options.chat?.auto_open_community;
+			if (this.app.options.chat?.black_list) {
 				this.black_list = this.app.options.chat.black_list;
 			}
 		}
@@ -1769,10 +1877,9 @@ class Chat extends ModTemplate {
 		}
 
 		this.app.storage.saveOptions();
-
 	}
 
-	saveOptions(){
+	saveOptions() {
 		this.app.options.chat.enable_notifications = this.enable_notifications;
 		this.app.options.chat.audio_notifications = this.audio_notifications;
 		this.app.options.chat.auto_open_community = this.auto_open_community;
@@ -1780,7 +1887,6 @@ class Chat extends ModTemplate {
 
 		this.app.storage.saveOptions();
 	}
-
 
 	async loadChatGroups() {
 		if (!this.app.BROWSER) {
@@ -1858,7 +1964,7 @@ class Chat extends ModTemplate {
 		let key_to_update = '';
 		for (let i = 0; i < this.groups.length; i++) {
 			if (this.groups[i].id === group.id) {
-				if (this.groups[i].members.length == 2) {
+				if (this.groups[i].members.length == 2 && !this.groups[i]?.member_ids) {
 					for (let member of this.groups[i].members) {
 						if (member !== this.publicKey) {
 							key_to_update = member;
@@ -1887,6 +1993,21 @@ class Chat extends ModTemplate {
 		await localforage.removeItem(`chat_${group.id}`);
 
 		this.app.connection.emit('chat-manager-render-request');
+	}
+
+	generateChatGroupLink(group) {
+		let obj = {
+			id: group.id,
+			name: group.name,
+			member_ids: group.member_ids
+		};
+
+		let base64obj = this.app.crypto.stringToBase64(JSON.stringify(obj));
+
+		let link = window.location.origin + '/chat?chat_id=' + base64obj;
+
+		navigator.clipboard.writeText(link);
+		siteMessage('Link Copied', 2000);
 	}
 
 	async onUpgrade(type, privatekey, walletfile) {

--- a/mods/chat/chat.js
+++ b/mods/chat/chat.js
@@ -49,7 +49,7 @@ class Chat extends ModTemplate {
 		this.communityGroup = null;
 		this.communityGroupName = 'Saito Community Chat';
 
-		this.debug = true;
+		this.debug = false;
 
 		this.chat_manager = null;
 
@@ -248,6 +248,9 @@ class Chat extends ModTemplate {
 				let chat_group = JSON.parse(
 					this.app.crypto.base64ToString(chat_id)
 				);
+
+				console.log(chat_group);
+
 				let search = this.returnGroup(chat_group.id);
 				if (search) {
 					//data.id = group id

--- a/mods/chat/chat.js
+++ b/mods/chat/chat.js
@@ -308,6 +308,8 @@ class Chat extends ModTemplate {
 			);
 			this.communityGroup.members = [peer.publicKey];
 
+			this.communityGroup.description = "an open forum for anyone on Saito to chat";
+
 			if (this.communityGroup) {
 				//
 				// remove duplicate public chats caused by server update

--- a/mods/chat/chat.js
+++ b/mods/chat/chat.js
@@ -228,8 +228,6 @@ class Chat extends ModTemplate {
 			window.innerWidth > 599
 		) {
 			this.chat_manager.chat_popup_container = '.saito-main';
-			//Main Chat Application doesn't use popups as such...
-			this.chat_manager.render_popups_to_screen = 0;
 		}
 
 		this.chat_manager.render_manager_to_screen = 1;
@@ -418,17 +416,11 @@ class Chat extends ModTemplate {
 						if (this.app.BROWSER) {
 							let active_module =
 								app.modules.returnActiveModule();
-							if (
-								app.browser.isMobileBrowser(
-									navigator.userAgent
-								) ||
+							if (app.browser.isMobileBrowser(navigator.userAgent) ||
 								window.innerWidth < 600 ||
 								active_module?.request_no_interrupts
 							) {
-								this.app.connection.emit(
-									'chat-manager-request-no-interrupts'
-								);
-								return;
+								this.app.connection.emit('chat-manager-request-no-interrupts');
 							}
 
 							this.app.connection.emit('chat-ready');

--- a/mods/chat/lib/appspace/chat-sidebar.js
+++ b/mods/chat/lib/appspace/chat-sidebar.js
@@ -56,7 +56,6 @@ class ChatSidebar {
     let index = 0;
 
     for (let am of availableMods){
-      console.log(am.returnName());
       if (am.returnName() !== this.mod.returnName()){
         let item = am.respondTo("user-menu", { publicKey: user_publickey });
         if (item instanceof Array) {

--- a/mods/chat/lib/appspace/chat-sidebar.js
+++ b/mods/chat/lib/appspace/chat-sidebar.js
@@ -27,18 +27,23 @@ class ChatSidebar {
     if (chat){
 
 
-      if (chat?.member_ids) {
+      if (chat?.member_ids || chat.members.length > 2) {
+        console.log("Chat - Defined group");
         // Multiparty Group
       } else if (chat.id == this.mod.communityGroup?.id || chat.name == this.mod.communityGroupName) {
         // Community Chat
-      } else {
+        console.log("Chat - Community");
+      } else if (chat.members.length == 2) {
         // 1-1 chat
+        console.log("Chat - P2P");
         for (let member of chat.members) {
           if (member !== this.mod.publicKey) {
             this.addUserMenu(member);
             break;
           }
         }
+      }else{
+        console.log("Chat - Undefined group");
       }
 
       this.attachEvents(chat);  

--- a/mods/chat/lib/appspace/chat-sidebar.js
+++ b/mods/chat/lib/appspace/chat-sidebar.js
@@ -27,7 +27,7 @@ class ChatSidebar {
     if (chat){
 
 
-      if (chat.members.length > 2) {
+      if (chat?.member_ids) {
         // Multiparty Group
       } else if (chat.id == this.mod.communityGroup?.id || chat.name == this.mod.communityGroupName) {
         // Community Chat

--- a/mods/chat/lib/appspace/chat-sidebar.template.js
+++ b/mods/chat/lib/appspace/chat-sidebar.template.js
@@ -7,8 +7,9 @@ module.exports = ChatSideTemplate = (app, mod, group) => {
 	let groupName = group.name;
 	let identicon = app.keychain.returnIdenticon(groupKey, 'png');
 
-	if (group.members.length > 2) {
+	if (group.member_ids) {
 		// Multiparty Group
+		groupKey = "";
 	} else if (group.id == mod.communityGroup?.id || group.name == mod.communityGroupName) {
 		// Community Chat
 		// If the peerservices haven't come up, we won't have a communityGroup obj yet....
@@ -40,9 +41,15 @@ module.exports = ChatSideTemplate = (app, mod, group) => {
         		<img class="saito-profile-identicon" src="${identicon}">
         		<div class="saito-profile-icons">${groupName}</div>
       		</div>
-     		<div class="saito-profile-info">
-      			<div class="saito-username">${groupKey}</div>
-      		</div>
+     		<div class="saito-profile-info">`;
+    if (groupKey){
+    	html += `<div class="saito-username">${groupKey}</div>`;
+    }
+    if (group?.description){
+    	html += `<div class="saito-profile-about">${group.description}</div>`;	
+    }
+    
+    html += `</div>
       		<div class="saito-profile-menu vertical">
       			<div id="chat-group-edit" class="saito-modal-menu-option"><i class="fa-solid fa-user-pen"></i><div>Manage Chat</div></div>
       		</div>

--- a/mods/chat/lib/appspace/chat-sidebar.template.js
+++ b/mods/chat/lib/appspace/chat-sidebar.template.js
@@ -1,3 +1,5 @@
+const MemberList = require("../overlays/member-list.template");
+
 module.exports = ChatSideTemplate = (app, mod, group) => {
 	if (!group) {
 		return '';
@@ -51,8 +53,9 @@ module.exports = ChatSideTemplate = (app, mod, group) => {
     
     html += `</div>
       		<div class="saito-profile-menu vertical">
-      			<div id="chat-group-edit" class="saito-modal-menu-option"><i class="fa-solid fa-user-pen"></i><div>Manage Chat</div></div>
+      			<div id="chat-group-edit" class="saito-modal-menu-option"><i class="fa-solid ${(group.id == mod.communityGroup?.id || group?.member_ids) ? "fa-users-gear": "fa-user-gear"}"></i><div>Manage Chat</div></div>
       		</div>
+      		${MemberList(app, mod, group)}
       	</div>
     </div>`;
 

--- a/mods/chat/lib/chat-manager/main.js
+++ b/mods/chat/lib/chat-manager/main.js
@@ -80,14 +80,12 @@ class ChatManager {
 		// handle requests to re-render chat popups
 		//
 		app.connection.on('chat-popup-remove-request', (group = null) => {
-			console.log('removing chat popup', group);
 			if (!group) {
 				return;
 			} else {
 				if (this.popups[group.id]) {
 					this.popups[group.id].remove();
 					delete this.popups[group.id];
-					console.log('removed chat popup', group);
 				}
 			}
 		});

--- a/mods/chat/lib/chat-manager/main.js
+++ b/mods/chat/lib/chat-manager/main.js
@@ -143,14 +143,6 @@ class ChatManager {
 						group = group2;
 					}
 				}
-				if (data.admin) {
-					//
-					// It may be overkill to send a group update transaction everytime the admin starts a chat
-					// But if groups have variable memberships, it does push out an update to everyone as long
-					// as the admin has an accurate list
-					//
-					this.mod.sendCreateGroupTransaction(group);
-				}
 			}
 
 			//

--- a/mods/chat/lib/chat-manager/main.js
+++ b/mods/chat/lib/chat-manager/main.js
@@ -153,6 +153,7 @@ class ChatManager {
 			}
 
 			app.connection.emit('chat-popup-render-request', group);
+			app.connection.emit("chat-manager-opens-group", group);
 		});
 
 		app.connection.on('relay-is-online', (pkey) => {

--- a/mods/chat/lib/chat-manager/popup.js
+++ b/mods/chat/lib/chat-manager/popup.js
@@ -192,7 +192,7 @@ class ChatPopup {
 
 			// add call icon, ignore if community chat
 			let mods = this.app.modules.mods;
-			if (this.group.name != this.mod.communityGroupName && this.group.members.length == 2) {
+			if (this.group.name != this.mod.communityGroupName && this.group.members.length == 2 && !this.group?.member_ids) {
 				let index = 0;
 				for (const mod of mods) {
 					let item = mod.respondTo('chat-actions', {

--- a/mods/chat/lib/chat-manager/popup.template.js
+++ b/mods/chat/lib/chat-manager/popup.template.js
@@ -14,7 +14,7 @@ module.exports = (app, mod, group, isStatic = false) => {
 
 	let is_encrypted = ``;
 
-	if (group.members.length == 2) {
+	if (group.members.length == 2 && !group.member_ids) {
 		for (let member of group.members) {
 			if (member !== mod.publicKey) {
 				if (app.keychain.hasSharedSecret(member)) {
@@ -26,7 +26,7 @@ module.exports = (app, mod, group, isStatic = false) => {
 
 	let html = `
        <div class="${class_name} chat-popup ${
-	group.members.length == 2 ? 'saito-dm-chat' : ''
+	group.members.length == 2 && !group?.member_ids ? 'saito-dm-chat' : ''
 }" id="chat-popup-${group.id}">
 
           <div class="chat-header" id="chat-header-${group.id}">
@@ -59,7 +59,7 @@ module.exports = (app, mod, group, isStatic = false) => {
 
               ${
 	group.name != mod.communityGroupName &&
-					group.members.length == 2
+					group.members.length == 2 && !group?.member_ids
 		? `
               <div class="chat-action-icons">
                 <div class="chat-actions"></div>

--- a/mods/chat/lib/chat-manager/teaser.template.js
+++ b/mods/chat/lib/chat-manager/teaser.template.js
@@ -27,7 +27,7 @@ module.exports = ChatTeaser = (app, mod, group, chat_open) => {
 
 	let identicon_source = id;
 
-	if (group.members.length == 2) {
+	if (group.members.length == 2 && !group?.member_ids) {
 		for (let mem of group.members) {
 			if (mem !== mod.publicKey) {
 				identicon_source = mem;

--- a/mods/chat/lib/overlays/chat-manager-menu.template.js
+++ b/mods/chat/lib/overlays/chat-manager-menu.template.js
@@ -25,13 +25,19 @@ module.exports = ChatManagerMenuTemplate = (app, mod) => {
 
 	html += 
 		`<fieldset id="add-contacts" class="saito-grid settings-link">
-			<i class="fa-solid fa-plus"></i>
-			<label>create new chat</label>
+			<i class="fa-solid fa-user-plus"></i>
+			<label>new chat</label>
+		</fieldset>`;
+
+	html += 
+		`<fieldset id="create-group" class="saito-grid settings-link">
+			<i class="fa-solid fa-users"></i>
+			<label>new group</label>
 		</fieldset>`;
 
 	html += 
 		`<fieldset id="edit-contacts" class="saito-grid settings-link">
-			<i class="fa-solid fa-users"></i>
+			<i class="fa-solid fa-users-gear"></i>
 			<label>manage chats</label>
 		</fieldset>`;
 

--- a/mods/chat/lib/overlays/chat-manager-menu.template.js
+++ b/mods/chat/lib/overlays/chat-manager-menu.template.js
@@ -25,7 +25,7 @@ module.exports = ChatManagerMenuTemplate = (app, mod) => {
 
 	html += 
 		`<fieldset id="add-contacts" class="saito-grid settings-link">
-			<i class="fa-solid fa-user-plus"></i>
+			<i class="fa-solid fa-user-group"></i>
 			<label>new chat</label>
 		</fieldset>`;
 

--- a/mods/chat/lib/overlays/chat-user-menu.js
+++ b/mods/chat/lib/overlays/chat-user-menu.js
@@ -53,9 +53,7 @@ class ChatUserMenu {
 							'admin'
 					) {
 						console.log('Send new name as group tx');
-						thisobj.mod.sendCreateGroupTransaction(
-							thisobj.chat_group
-						);
+						thisobj.mod.sendUpdateGroupTransaction(thisobj.chat_group);
 					}
 					thisobj.mod.saveChatGroup(thisobj.chat_group);
 					thisobj.app.connection.emit('chat-manager-render-request');

--- a/mods/chat/lib/overlays/chat-user-menu.js
+++ b/mods/chat/lib/overlays/chat-user-menu.js
@@ -30,7 +30,7 @@ class ChatUserMenu {
 
 		let suggestedName = this.chat_group.name;
 
-		if (this.chat_group.members.length == 2) {
+		if (this.chat_group.members.length == 2 && !this.chat_group?.member_ids) {
 			for (let m of this.chat_group.members) {
 				if (m !== this.mod.publicKey) {
 					suggestedName = m;
@@ -47,11 +47,7 @@ class ChatUserMenu {
 				if (name) {
 					thisobj.chat_group.name = sanitize(name);
 
-					if (
-						thisobj.chat_group?.member_ids &&
-						thisobj.chat_group.member_ids[thisobj.mod.publicKey] ==
-							'admin'
-					) {
+					if (thisobj.chat_group?.member_ids[thisobj.mod.publicKey] == 'admin' ) {
 						console.log('Send new name as group tx');
 						thisobj.mod.sendUpdateGroupTransaction(thisobj.chat_group);
 					}
@@ -91,6 +87,12 @@ class ChatUserMenu {
 			}
 		}
 
+		if (document.getElementById("invite")){
+			document.getElementById('invite').onclick = (e) => {
+				this.mod.generateChatGroupLink(this.chat_group);
+			}
+		}
+
 
 		if (document.getElementById('delete')) {
 			document.getElementById('delete').onclick = async (e) => {
@@ -104,40 +106,48 @@ class ChatUserMenu {
 			};
 		}
 
-		if (document.getElementById('invite')) {
-			document.getElementById('invite').onclick = (e) => {
+		if (document.getElementById('admin')) {
+			document.getElementById('admin').onclick = (e) => {
 				const contactList = new ContactsList(this.app, this.mod, false);
+
 				contactList.callback = async (person) => {
 					if (person) {
-						//Add here, not on receiveTX
+
 						if (!thisobj.chat_group.members.includes(person)) {
 							thisobj.chat_group.members.push(person);
 						}
 
-						if (!thisobj.chat_group.member_ids[person]) {
-							thisobj.chat_group.member_ids[person] = 0;
-						}
+						thisobj.chat_group.member_ids[person] = "admin";
 
-						this.mod.sendAddMemberTransaction(
-							thisobj.chat_group,
-							person
-						);
+						thisobj.mod.sendUpdateGroupTransaction(thisobj.chat_group);
 
 						this.mod.saveChatGroup(thisobj.chat_group);
 						thisobj.overlay.remove();
 						thisobj.render();
-						siteMessage('User invited to chat group', 2000);
 					}
 				};
-				contactList.render();
+				contactList.render(thisobj.chat_group.members);
 			};
+		}
+
+		if (document.getElementById('leave')){
+			document.getElementById('leave').onclick = async (e) => {
+				await this.mod.sendRemoveMemberTransaction(
+						thisobj.chat_group,
+						this.mod.publicKey
+					);
+
+				this.mod.deleteChatGroup(thisobj.chat_group);
+				siteMessage('You left the chat group', 2000);
+				thisobj.overlay.remove();
+			}
 		}
 
 		document.querySelectorAll('.remove_user').forEach((user) => {
 			user.onclick = async (e) => {
 				let user_id = e.currentTarget.dataset.id;
 				if (user_id) {
-					this.mod.sendRemoveMemberTransaction(
+					await this.mod.sendRemoveMemberTransaction(
 						thisobj.chat_group,
 						user_id
 					);
@@ -169,20 +179,6 @@ class ChatUserMenu {
 			};
 		});
 
-		document
-			.querySelectorAll('.saito-contact.unconfirmed')
-			.forEach((user) => {
-				user.onclick = (e) => {
-					let user_id = e.currentTarget.dataset.id;
-					if (user_id) {
-						this.mod.sendAddMemberTransaction(
-							thisobj.chat_group,
-							user_id
-						);
-						siteMessage('Chat Group invite resent', 2000);
-					}
-				};
-			});
 	}
 }
 

--- a/mods/chat/lib/overlays/chat-user-menu.template.js
+++ b/mods/chat/lib/overlays/chat-user-menu.template.js
@@ -3,7 +3,7 @@ module.exports = (app, mod, chat_group) => {
    <div class="saito-modal saito-modal-menu" id="saito-chat-menu">
     <div class="saito-modal-title">${chat_group.name}</div>
      <div class="saito-modal-content">
-      <div id="rename" class="saito-modal-menu-option"><i class="fas fa-user-edit"></i><div>Rename</div></div>`;
+      <div id="rename" class="saito-modal-menu-option"><i class="fa-regular fa-id-card"></i><div>Rename</div></div>`;
 
 	if (chat_group?.muted) {
 		html += `<div id="unmute" class="saito-modal-menu-option"><i class="fa-solid fa-volume"></i><div>Unmute</div></div>`;
@@ -22,57 +22,20 @@ module.exports = (app, mod, chat_group) => {
 	}
 
 	if (chat_group.member_ids) {
-		if (chat_group.member_ids[mod.publicKey] == 'admin') {
-			html += `<div id="admin" class="saito-modal-menu-option"><i class="fa-solid fa-user-plus"></i><div>Add Admin</div></div>`;
-		}
 
 		html += `<div id="invite" class="saito-modal-menu-option"><i class="fas fa-link"></i><div>Add member</div></div>`;
 
+		if (chat_group.member_ids[mod.publicKey] == 'admin') {
+			html += `<div id="admin" class="saito-modal-menu-option"><i class="fa-solid fa-user-plus"></i><div>Add Admin</div></div>`;
+			html += `<div id="remove" class="saito-modal-menu-option"><i class="fa-solid fa-user-minus"></i><div>Remove member</div></div>`;
+		}else{
+			html += `<div id="view" class="saito-modal-menu-option"><i class="fa-solid fa-users"></i><div>View members</div></div>`;			
+		}
+
 		html += `</div>`;
 
-		html += `<div class="saito-modal-content">`;
+		//User List
 
-		for (let publickey in chat_group.member_ids) {
-			let imgsrc = app.crypto.isPublicKey(publickey)
-				? app.keychain.returnIdenticon(publickey)
-				: '';
-			let name = app.keychain.returnIdentifierByPublicKey(
-				publickey,
-				true
-			);
-			if (name == publickey) {
-				name = 'Anonymous User';
-			}
-
-			let unconfirmed_tag = '';
-			//
-			//only display for admin
-			//
-			if (chat_group.member_ids[mod.publicKey] == 'admin') {
-				if (!chat_group.member_ids[publickey]) {
-					unconfirmed_tag = ' unconfirmed';
-				}
-			}
-			html += `<div class="saito-contact${unconfirmed_tag}" data-id="${publickey}">`;
-
-			html += `<div class="saito-user">
-                <div class="saito-identicon-box"><img class="saito-identicon" src="${imgsrc}">${
-				chat_group.member_ids[publickey] == 'admin'
-					? `<i class="saito-overlaid-icon fa-solid fa-dragon"></i>`
-					: ''
-			}</div>
-                  ${name}
-                <div class="saito-userline">${publickey}</div>
-                ${
-					chat_group.member_ids[mod.publicKey] == 'admin' ||
-					publickey === mod.publicKey
-						? `<div class="remove_user saito-user-fourth-elem-large" data-id="${publickey}"><i class="fa-solid fa-user-minus"></i></div>`
-						: '<div></div>'
-				}
-              </div>
-            </div>`;
-		}
-		html += '</div>';
 	}
 
 	html += '</div>';

--- a/mods/chat/lib/overlays/chat-user-menu.template.js
+++ b/mods/chat/lib/overlays/chat-user-menu.template.js
@@ -5,29 +5,31 @@ module.exports = (app, mod, chat_group) => {
      <div class="saito-modal-content">
       <div id="rename" class="saito-modal-menu-option"><i class="fas fa-user-edit"></i><div>Rename</div></div>`;
 
-    if (chat_group?.muted){
-		html += `<div id="unmute" class="saito-modal-menu-option"><i class="fa-solid fa-volume"></i><div>Unmute</div></div>`;	
-    }else{
-    	html += `<div id="mute" class="saito-modal-menu-option"><i class="fa-solid fa-volume-xmark"></i><div>Mute</div></div>`;	
-    }
-    html += `<div id="delete" class="saito-modal-menu-option"><i class="fas fa-trash-alt"></i><div>Clear History</div></div>
+	if (chat_group?.muted) {
+		html += `<div id="unmute" class="saito-modal-menu-option"><i class="fa-solid fa-volume"></i><div>Unmute</div></div>`;
+	} else {
+		html += `<div id="mute" class="saito-modal-menu-option"><i class="fa-solid fa-volume-xmark"></i><div>Mute</div></div>`;
+	}
+	html += `<div id="delete" class="saito-modal-menu-option"><i class="fas fa-trash-alt"></i><div>Clear History</div></div>
       `;
 
-      if (chat_group.id !== mod.communityGroup.id){
-      	if (chat_group.members.length == 2){
-      		html += `<div id="block" class="saito-modal-menu-option"><i class="fas fa-ban"></i><div>Delete and Block</div></div>`;	
-      	}else{
-      		html += `<div id="leave" class="saito-modal-menu-option"><i class="fa-solid fa-door-open"></i><div>Leave Group</div></div>`;	
-      	}
-      	
-      }
+	if (chat_group.id !== mod.communityGroup.id) {
+		if (chat_group.member_ids) {
+			html += `<div id="leave" class="saito-modal-menu-option"><i class="fa-solid fa-door-open"></i><div>Leave Group</div></div>`;
+		} else {
+			html += `<div id="block" class="saito-modal-menu-option"><i class="fas fa-ban"></i><div>Delete and Block</div></div>`;
+		}
+	}
 
 	if (chat_group.member_ids) {
 		if (chat_group.member_ids[mod.publicKey] == 'admin') {
-			html += `<div id="invite" class="saito-modal-menu-option"><i class="fa-solid fa-user-plus"></i><div>Add Member</div></div>`;
+			html += `<div id="admin" class="saito-modal-menu-option"><i class="fa-solid fa-user-plus"></i><div>Add Admin</div></div>`;
 		}
 
+		html += `<div id="invite" class="saito-modal-menu-option"><i class="fas fa-link"></i><div>Add member</div></div>`;
+
 		html += `</div>`;
+
 		html += `<div class="saito-modal-content">`;
 
 		for (let publickey in chat_group.member_ids) {
@@ -55,18 +57,18 @@ module.exports = (app, mod, chat_group) => {
 
 			html += `<div class="saito-user">
                 <div class="saito-identicon-box"><img class="saito-identicon" src="${imgsrc}">${
-	chat_group.member_ids[publickey] == 'admin'
-		? `<i class="saito-overlaid-icon fa-solid fa-dragon"></i>`
-		: ''
-}</div>
+				chat_group.member_ids[publickey] == 'admin'
+					? `<i class="saito-overlaid-icon fa-solid fa-dragon"></i>`
+					: ''
+			}</div>
                   ${name}
                 <div class="saito-userline">${publickey}</div>
                 ${
-	chat_group.member_ids[mod.publicKey] == 'admin' ||
+					chat_group.member_ids[mod.publicKey] == 'admin' ||
 					publickey === mod.publicKey
-		? `<div class="remove_user saito-user-fourth-elem-large" data-id="${publickey}"><i class="fa-solid fa-user-minus"></i></div>`
-		: '<div></div>'
-}
+						? `<div class="remove_user saito-user-fourth-elem-large" data-id="${publickey}"><i class="fa-solid fa-user-minus"></i></div>`
+						: '<div></div>'
+				}
               </div>
             </div>`;
 		}

--- a/mods/chat/lib/overlays/member-list.template.js
+++ b/mods/chat/lib/overlays/member-list.template.js
@@ -1,0 +1,43 @@
+module.exports = (app, mod, chat_group) => {
+	let html = `<div class="saito-modal-content">`;
+
+	for (let publickey in chat_group.member_ids) {
+		let imgsrc = app.crypto.isPublicKey(publickey)
+			? app.keychain.returnIdenticon(publickey)
+			: '';
+		let name = app.keychain.returnIdentifierByPublicKey(publickey, true);
+		if (name == publickey) {
+			name = 'Anonymous User';
+		}
+
+		let unconfirmed_tag = '';
+		//
+		//only display for admin
+		//
+		if (chat_group.member_ids[mod.publicKey] == 'admin') {
+			if (chat_group.member_ids[publickey] == 0) {
+				unconfirmed_tag = ' unconfirmed';
+			}
+		}
+		html += `<div class="saito-contact${unconfirmed_tag}" data-id="${publickey}">`;
+
+		html += `<div class="saito-user">
+                <div class="saito-identicon-box"><img class="saito-identicon" src="${imgsrc}">${
+			chat_group.member_ids[publickey] == 'admin'
+				? `<i class="saito-overlaid-icon fa-solid fa-dragon"></i>`
+				: ''
+		}</div>
+                  ${name}
+                <div class="saito-userline">${publickey}</div>
+                ${
+					chat_group.member_ids[mod.publicKey] == 'admin' && chat_group.member_ids[publickey] !== "admin"
+						? `<div class="remove_user saito-user-fourth-elem-large" data-id="${publickey}"><i class="fa-solid fa-user-minus"></i></div>`
+						: '<div></div>'
+				}
+              </div>
+            </div>`;
+	}
+	html += '</div>';
+
+	return html;
+};

--- a/mods/chat/web/css/chat-sidebar.css
+++ b/mods/chat/web/css/chat-sidebar.css
@@ -15,7 +15,8 @@
 .chat-sidebar .saito-modal-menu-option {
 	font-size: 2rem;
 	height: unset;
-	width: 100%;
+	width: calc(100% - 2rem);
+	margin: 0 1rem;
 }
 
 .chat-sidebar .saito-modal-menu-option > div {

--- a/mods/encrypt/encrypt.js
+++ b/mods/encrypt/encrypt.js
@@ -61,7 +61,7 @@ class Encrypt extends ModTemplate {
 
       return {
         text: "Add Contact",
-        icon: "far fa-id-card",
+        icon: "fa-solid fa-user-lock",
         callback: function (app, publicKey) {
           encrypt_self.app.keychain.saveKeys();
           encrypt_self.initiate_key_exchange(publicKey, 0);

--- a/mods/redsquare/redsquare.js
+++ b/mods/redsquare/redsquare.js
@@ -179,7 +179,7 @@ class RedSquare extends ModTemplate {
     let this_mod = this;
     if (type === "user-menu") {
       return {
-        text: `View ${obj?.publicKey && obj.publicKey === this.publicKey ? "My " : ""}Profile`,
+        text: `${obj?.publicKey && obj.publicKey === this.publicKey ? "My" : "View"} RedSquare Profile`,
         icon: "fa fa-user",
         callback: function (app, publicKey) {
           if (app.modules.returnActiveModule().returnName() == "Red Square") {

--- a/web/saito/css-imports/saito-overlay.css
+++ b/web/saito/css-imports/saito-overlay.css
@@ -225,8 +225,10 @@
 
 
 .module-settings-overlay {
-    width: min(800px, 95vw);
-    height: min(400px, 90vh);
+    min-width: min(800px, 90vw);
+    min-height: min(400px, 90vh);
+    max-width: 95vw;
+    max-height: 95vh;
     padding: 2rem;
     background: var(--saito-background-color);
     border-radius: 0.5rem;

--- a/web/saito/css-imports/saito-profile.css
+++ b/web/saito/css-imports/saito-profile.css
@@ -3,6 +3,7 @@
 }
 
 .saito-profile-menu {
+  margin-left: 0.2rem;
 }
 
 .saito-profile-menu > div {
@@ -45,7 +46,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  margin: 2rem 0 0.5rem 0.2rem;
+  margin: 2rem 0 0.5rem 1.2rem;
 }
 
 
@@ -53,7 +54,6 @@
   font-size: 1.8rem;
   overflow: hidden;
   text-overflow: ellipsis;
-  margin-left: 1rem;
 }
 
 .saito-follow {


### PR DESCRIPTION
This is a rewrite of the chat-group logic that was previously inspired by getting leagues up and running.

We can:
- create (empty other than us) groups
- join a group via URL
- promote a group member to admin (admin only)
- ban a group member (admin only)
- rename a group (admin only)

Other work:
- Opening chat page via URL with parameter loads the chat history
- Chat sidebar list group members
- auto open community chat now works in chat/
- games auto open player chat, but keep other chats silent (unless player actively opens them) [MAJOR UX improvement!!!!]
- minor usability bugs caused by the amorphousness of types of chat groups, e.g. community chat, 1-1 chats, user created group chats, auto created group chats....

members.length == 2 may be a 1-1 chat, but sometimes we add ourselves as a member in community chat, or a group chat temporarily has only 2 members.... it takes some complicated logic to not be surfacing the wrong UI elements