### PR TITLE
Modify mentions regex

### DIFF
--- a/mods/chat/chat.js
+++ b/mods/chat/chat.js
@@ -1527,7 +1527,7 @@ class Chat extends ModTemplate {
 						sender = block[z].from[0];
 						
 						// replace @mentions with saito treated address
-						block[z].msg = block[z].msg.replaceAll(/(?=@)([^\s]*)/g, function(k){
+						block[z].msg = block[z].msg.replaceAll(/(?<=^|(?<=[^a-zA-Z0-9-_\.]))@([^\s]*)/g, function(k){
 							let split = (k.split('@'));
 							let username = '';
 							let key = '';

--- a/mods/redsquare/lib/tweet.template.js
+++ b/mods/redsquare/lib/tweet.template.js
@@ -16,7 +16,7 @@ module.exports = (app, mod, tweet) => {
 	}
 
 	// replace @ key/identifer
-	text = text.replaceAll(/(?=@)([^\s]*)/g, function(k){
+	text = text.replaceAll(/(?<=^|(?<=[^a-zA-Z0-9-_\.]))@([^\s]*)/g, function(k){
 		let split = (k.split('@'));
 		let username = '';
 		let key = '';


### PR DESCRIPTION
Email not screwing up now, have modified the mentions regex. Although the end part of email is considered as link by sanitize() method (created a ticket for this issue in backlog)

![Image](https://github.com/SaitoTech/saito-lite-rust/assets/104337801/76d0c339-7e53-4342-9ee8-3930753d1c05)

