### PR TITLE
Show to/from transaction details in history overlay

### DIFF
--- a/lib/saito/ui/saito-crypto/overlays/history.js
+++ b/lib/saito/ui/saito-crypto/overlays/history.js
@@ -24,8 +24,10 @@ class MixinHistory {
 		).innerHTML = '';
 
 		if (this.mod.ticker != 'SAITO') {
-			this.mod.returnHistory(this.mod.asset_id, 1000, (d) => {
+			this.mod.returnHistory(this.mod.asset_id, 1000, async (d) => {
 				this.history_data = d;
+
+				console.log('history data:', d);
 				let html = '';
 				if (d.length > 0) {
 					for (let i = (d.length - 1); i >= 0; i--) {
@@ -41,10 +43,8 @@ class MixinHistory {
 
   						if (i < d.length-1) {
 							if (Number(d[i+1].amount) > 0) {
-								console.log('if amount ');
 								balance = balance - Math.abs(Number(d[i+1].amount));
 							} else {
-								console.log('else amount ');
 								balance = balance + Math.abs(Number(d[i+1].amount));
 							}
 						}
@@ -59,13 +59,47 @@ class MixinHistory {
 				          maximumFractionDigits: decimals
 				        });
 				        let balance_as_float = parseFloat(balance);
+				       	
+				       	let opponnent = (typeof d[i].opponent_id != 'undefined')  ? 
+				       	d[i].opponent_id : null;
 				       
+				       	let sender_html = '';
+				       	if (opponnent != null && opponnent != '') {
+				       		// Showing details for internal mixin transaction details
+				       		let user_data = await this.mod.getAddressByUserId(opponnent, this.mod.asset_id);
+				       		if (user_data != null) {
+				       			let public_key = user_data.publickey;
+				       			let address = user_data.address;
+
+				       			let identicon = this_history.app.keychain.returnIdenticon(public_key);
+							    let username = this_history.app.keychain.returnUsername(public_key);
+				       			sender_html = `<div class="saito-identicon-container">
+									        <img class="saito-identicon" src="${identicon}">  
+									        <div class="transfer-address">
+									          <div class="to-publickey">${username}</div>
+									          ${(address != '') ? `<div class="to-address">${address}</div>` : ``}
+									        </div>
+									      </div>`;
+				       		} 
+				       	} else {
+				       		// Mixin sdk throwing error when fetching tx details.
+				       		// Temproraily redirecting users to mixin explorer for
+				       		// external transaction details
+				       		let trans_hash = d[i].transaction_hash;
+			       			sender_html = `<a class="history-tx-link" href="https://viewblock.io/mixin/tx/${trans_hash}"
+			       							target="_blank">
+			       								<div class="history-tx-id">${trans_hash}</div>
+			       								<i class="fa-solid fa-arrow-up-right-from-square"></i>
+			       							</a>`;
+			       		}
+
 						html += `<div class='saito-table-row'>
 	                        <div class='mixin-his-created-at'>${created_at}</div>
 	                        <div>${type}</div>
 	                        <div class='${type.toLowerCase()}'>${amount} ${this_history.mod.ticker}</div>
 	                        <div>${(nf.format(balance_as_float)).toString()} ${this_history.mod.ticker}</div>
-	                      </div>`; /* right now we dont get `status` in /snapshot api, all row are `success`*/
+	                        <div>${sender_html}</div>
+	                      </div>`; 
 					}
 
 					document.querySelector(

--- a/lib/saito/ui/saito-crypto/overlays/history.template.js
+++ b/lib/saito/ui/saito-crypto/overlays/history.template.js
@@ -8,6 +8,7 @@ module.exports = HistoryTemplate = (app, mod, this_history) => {
                  <div>Type</div>
                  <div>Amount</div>
                  <div>Balance</div>
+                 <div>To/From</div>
             </div>
             <div class="saito-table-body">
                 <p>Loading history...</p>

--- a/mods/mixin/lib/mixinmodule.js
+++ b/mods/mixin/lib/mixinmodule.js
@@ -544,6 +544,23 @@ class MixinModule extends CryptoModule {
 		}
 	}
 
+	async getAddressByUserId(user_id, asset_id){
+		let address = null;
+		await this.mixin.sendFetchAddressByUserIdTransaction({
+			user_id: user_id,
+			asset_id: asset_id
+		}, 
+		function(res){
+			console.log('returning address 1////', res);
+			if (res.length > 0) {
+				address = res[0];
+			}
+		});
+
+		console.log('returning address 2////');
+		return address;
+	}
+
 	async addCryptoAddressToKey(publicKey, address, ticker){
 		console.log('address, asset_id', address, ticker);
 		let crypto_addresses = {};
@@ -596,6 +613,12 @@ class MixinModule extends CryptoModule {
 		} catch(err) {
 			console.error("Error 'validateAddress' MixinModule: ", err);
 		}
+	}
+
+	async fetchTransaction(transaction_id){
+		return await this.mixin.fetchSafeTransaction(transaction_id, function(res){
+			console.log('inside miximodule fetchTransaction ///', res);
+		});
 	}
 
 }

--- a/web/saito/css-imports/saito-wallet.css
+++ b/web/saito/css-imports/saito-wallet.css
@@ -258,6 +258,7 @@
 .mixin-txn-his-container .saito-table-body {
   height: auto;
   margin-top: 1rem;
+  overflow-x: hidden;
 }
 
 .mixin-txn-his-container .saito-table-row {
@@ -269,13 +270,38 @@
 }
 
 .mixin-txn-his-container .saito-table-header {
-  grid-template-columns: 16rem 16rem 15rem 15rem;
+  grid-template-columns: 16rem 16rem 15rem 15rem 15rem;
   text-align: center;
 }
 
 .mixin-txn-his-container .saito-table-row {
-  grid-template-columns: 16rem 16rem 14rem 16rem;
+  grid-template-columns: 16rem 16rem 14rem 16rem 35rem;
   text-align: center;
+  align-items: center;
+}
+
+.history-tx-link {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+}
+
+.history-tx-id {
+  padding: 1.5rem 0rem;
+  display: block;
+  min-width: 25rem;
+  overflow: hidden;
+  text-overflow: clip;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.saito-identicon-container {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 1rem;
 }
 
 .mixin-items-container {


### PR DESCRIPTION
For internal mixin transaction we have user's saito publickey so showing identicon and trx address.

For external transaction, currently mixin node sdk is throwing error when fetching transaction details, so redirecting users to mixin block explorer temporarily. (have contacted mixin team regarding this issue)


![Screenshot from 2024-04-02 15-51-59](https://github.com/SaitoTech/saito-lite-rust/assets/104337801/a2296520-e72e-4717-82bf-05b9656a58e9)
