### PR TITLE
Videocall setting changes

### DIFF
--- a/mods/videocall/lib/StreamManager.js
+++ b/mods/videocall/lib/StreamManager.js
@@ -150,6 +150,9 @@ class StreamManager {
 						peerConnection.addTrack(videoTrack);
 					}
 				});
+
+				this.app.connection.emit('toggle-screen-share-label','Stop Screen');
+
 			} catch (err) {
 				console.error('Error accessing media devices.', err);
 			}
@@ -162,6 +165,11 @@ class StreamManager {
 
 			console.log('no more');
 			this.endPresentation();
+			this.app.connection.emit('toggle-screen-share-label','Screen Share');
+		});
+
+		app.connection.on('toggle-screen-share-label', async (text) => {
+			document.querySelector('.screen_share label').innerText = text;
 		});
 
 		app.connection.on('stun-connection-connected', (peerId) => {

--- a/mods/videocall/lib/overlays/videocall-settings.js
+++ b/mods/videocall/lib/overlays/videocall-settings.js
@@ -27,20 +27,6 @@ class VideoCallSettings {
 			};
 		});
 
-		if (document.querySelector('.share-control')) {
-			document.querySelector('.share-control').onclick = (e) => {
-				e.preventDefault();
-				e.stopPropagation();
-				if (this_self.mod.screen_share) {
-					console.log('Emit event to stop');
-					this_self.app.connection.emit('stop-share-screen');
-				} else {
-					console.log('Emit event to start');
-					this_self.app.connection.emit('begin-share-screen');
-				}
-				this_self.saitoOverlay.remove();
-			};
-		}
 
 		if (document.querySelector('.advanced-settings-link')) {
 			document.querySelector('.advanced-settings-link').onclick = (e) => {

--- a/mods/videocall/lib/overlays/videocall-settings.template.js
+++ b/mods/videocall/lib/overlays/videocall-settings.template.js
@@ -2,80 +2,86 @@ const VideoCallSettingsTemplate = (display_mode, mod) => {
 	console.log('----- ', display_mode);
 
 	let html = `
-          <div class="videocall-setting-grid-item saito-modal">
+            <div class="saito-modal saito-modal-menu videocall-setting-grid-item" id="saito-user-menu">
+               <div class="saito-modal-title">Layout</div>
+               <div class="saito-modal-content">
 
-            <div class="videocall-option-grid">
-              <div class="videocall-setting-title">Change layout</div>
+                ${
+                    mod.screen_share
+                      ? `
+                      <div class="saito-modal-menu-option">
+                        <label class="videocall-option-label ${
+                          display_mode === 'presentation' ? `active` : ``
+                        }"  for="videocall-option-input-presentation">
+
+                        <input id="videocall-option-input-presentation" ${
+                            display_mode === 'presentation' ? `checked` : ``
+                          } type="radio" value="presentation"
+                          name="videocall-option-input" class="videocall-option-input">
+
+                        
+                          <i class="fa-solid fa-person-chalkboard"></i>
+                          <div>Presentation</div>
+                        </label>
+                      </div>
+
+                      `
+                      : ``
+                  }
+
+                  <div class="saito-modal-menu-option">
+                    <label class="videocall-option-label ${
+                      display_mode === 'focus' ? `active` : ``
+                    }"  for="videocall-option-input-focus">
+
+                    <input id="videocall-option-input-focus" ${
+                        display_mode === 'focus' ? `checked` : ``
+                      } type="radio" value="focus"
+                      name="videocall-option-input" class="videocall-option-input">
+
+                    
+                      <i class="fa-solid fa-users-viewfinder"></i>
+                      <div>Focus</div>
+                    </label>
+                  </div>
 
 
-              ${
-	mod.screen_share
-		? `
-              <div class="videocall-option-container">
-                <label class="videocall-option-label active" for="videocall-option-input-presentation">
-                  <input id="videocall-option-input-presentation" checked type="radio" value="presentation"
-                   name="videocall-option-input" class="videocall-option-input">
-                  <div class="videocall-option-name">Presentation</div> 
-                  <i class="fa-solid fa-person-chalkboard"></i>
-                </label>
-              </div>
-              `
-		: ``
-}
+                  <div class="saito-modal-menu-option">
+                    <label class="videocall-option-label ${
+                      display_mode === 'gallery' ? `active` : ``
+                    }"  for="videocall-option-input-gallery">
 
-              <div class="videocall-option-container">
-                <label class="videocall-option-label ${
-	display_mode === 'focus' ? `active` : ``
-}"  for="videocall-option-input-focus">
-                  <input id="videocall-option-input-focus" ${
-	display_mode === 'focus' ? `checked` : ``
-} type="radio" value="focus"
-                   name="videocall-option-input" class="videocall-option-input">
-                  <div class="videocall-option-name">Focus</div> 
-                  <i class="fa-solid fa-users-viewfinder"></i>
-                </label>
-              </div>
-            
-                <div class="videocall-option-container">
-                  <label class="videocall-option-label ${
-	display_mode === 'gallery' ? `active` : ``
-}" for="videocall-option-input-gallery">
                     <input id="videocall-option-input-gallery" ${
-	display_mode === 'gallery' ? `checked` : ``
-} type="radio" value="gallery" name="videocall-option-input" class="videocall-option-input">
-                    <div class="videocall-option-name">Gallery</div> 
-                    <i class="fa-solid fa-table-cells"></i>
-                  </label>
+                        display_mode === 'gallery' ? `checked` : ``
+                      } type="radio" value="gallery"
+                      name="videocall-option-input" class="videocall-option-input">
+
+
+                      <i class="fa-solid fa-table-cells"></i>
+                      <div>Gallery</div>
+                    </label>
+                  </div>
+
+
+                  <div class="saito-modal-menu-option">
+                    <label class="videocall-option-label ${
+                      display_mode === 'speaker' ? `active` : ``
+                    }"  for="videocall-option-input-speaker">
+
+                    <input id="videocall-option-input-speaker" ${
+                        display_mode === 'speaker' ? `checked` : ``
+                      } type="radio" value="speaker"
+                      name="videocall-option-input" class="videocall-option-input">
+
+
+                      <i class="fa-solid fa-user"></i>
+                      <div>Speaker</div>
+                    </label>
+                  </div>
+                  
+
                </div>
-              
-              <div class="videocall-option-container">
-                <label class="videocall-option-label ${
-	display_mode === 'speaker' ? `active` : ``
-}" for="videocall-option-input-speaker">
-                  <input id="videocall-option-input-speaker" ${
-	display_mode === 'speaker' ? `checked` : ``
-} type="radio" value="speaker" name="videocall-option-input" class="videocall-option-input">
-                  <div class="videocall-option-name">Speaker</div> 
-                  <i class="fa-solid fa-user"></i>
-                </label>
-              </div>
-            
-            </div>
-
-            <hr>
-
-
-            <div class="videocall-option-container share-control">
-              <label class="videocall-option-label" for="videocall-screenshare">
-              <input id="videocall-screenshare" ${
-	mod.screen_share ? `checked` : ``
-} type="checkbox" name="videocall-screenshare">
-                <div class="videocall-option-name">Share screen</div>
-                <i class="fa-solid fa-display"></i>
-              </label>
-            </div>
-
-          </div>
+             </div>
          
       `;
 

--- a/mods/videocall/lib/overlays/videocall-settings.template.js
+++ b/mods/videocall/lib/overlays/videocall-settings.template.js
@@ -75,13 +75,6 @@ const VideoCallSettingsTemplate = (display_mode, mod) => {
               </label>
             </div>
 
-            <hr>
-            
-            <div class="videocall-option-label">
-              <i class="fa-solid fa-sliders"></i>
-              <div class="videocall-option-name advanced-settings-link">Module Settings</div>
-            </div>
-
           </div>
          
       `;

--- a/mods/videocall/videocall.js
+++ b/mods/videocall/videocall.js
@@ -297,6 +297,18 @@ class Videocall extends ModTemplate {
 						);
 						call_self.loadSettings('.saito-module-settings');
 					}
+				},
+				{
+					text: 'Screen Share',
+					icon: 'fa-solid fa-display',
+					hook: 'screen_share',
+					callback: function (app) {
+						if (call_self.screen_share) {
+							call_self.app.connection.emit('stop-share-screen');
+						} else {
+							call_self.app.connection.emit('begin-share-screen');
+						}
+					}
 				}
 			];
 		}

--- a/mods/videocall/videocall.js
+++ b/mods/videocall/videocall.js
@@ -4,6 +4,7 @@ const CallLauncher = require('./lib/components/call-launch');
 const CallInterfaceVideo = require('./lib/components/call-interface-video');
 const CallInterfaceFloat = require('./lib/components/call-interface-float');
 const DialingInterface = require('./lib/components/dialer');
+const SaitoOverlay = require('../../lib/saito/ui/saito-overlay/saito-overlay');
 
 const StreamManager = require('./lib/StreamManager');
 const AppSettings = require('./lib/stun-settings');
@@ -278,11 +279,23 @@ class Videocall extends ModTemplate {
 		if (type === 'call-actions') {
 			return [
 				{
+					text: 'Layout',
+					icon: 'fa-solid fa-table-cells-large',
+					prepend: true,
+					callback: function (app) {
+						app.connection.emit('videocall-show-settings');
+					}
+				},
+				{
 					text: 'Settings',
 					icon: 'fa-solid fa-cog',
 					prepend: true,
 					callback: function (app) {
-						app.connection.emit('videocall-show-settings');
+						let anotherOverlay = new SaitoOverlay(call_self.app, call_self.mod);
+						anotherOverlay.show(
+							`<div class="videocall-setting-grid-item saito-module-settings"></div>`
+						);
+						call_self.loadSettings('.saito-module-settings');
 					}
 				}
 			];

--- a/mods/videocall/web/css/videocall-video-interface.css
+++ b/mods/videocall/web/css/videocall-video-interface.css
@@ -982,67 +982,11 @@ video#local {
 /*
   settings overlay
 */
-
-.videocall-setting-grid-item {
-	display: grid;
-	background: var(--saito-background-color);
-	color: var(--saito-font-color);
-	padding: 2rem;
-	font-size: 1.75rem;
-}
-
-.videocall-option-grid {
-	display: grid;
-	gap: 1.5rem;
-}
-
-.videocall-setting-title {
-	font-size: 2.2rem;
-}
-
 .videocall-option-label {
 	display: grid;
 	grid-template-columns: 0.07fr 1fr 0.1fr;
 	gap: 1.5rem;
 	align-items: center;
 	cursor: pointer;
-}
-
-.videocall-option-label:hover,
-.videocall-option-label.active {
-	background: var(--saito-background-light);
-}
-
-.videocall-option-name {
-	line-height: 4rem;
 	font-size: 2rem;
-}
-
-.videocall-option-label i {
-	font-size: 4rem;
-	color: var(--saito-font-color);
-	margin: auto;
-}
-
-.videocall-option-label i.fa-table-cells {
-	font-size: 4.5rem;
-}
-
-.videocall-option-label i.fa-user {
-	font-size: 3.5rem;
-}
-
-.videocall-setting-icon {
-	width: fit-content;
-}
-
-.videocall-setting-icon i {
-	font-size: 4rem;
-	transition: all 0.2s ease-in-out;
-	cursor: pointer;
-	color: var(--saito-font-color);
-}
-
-.videocall-setting-icon:hover i {
-	transform: scale(1.2);
 }

--- a/mods/videocall/web/css/videocall-video-interface.css
+++ b/mods/videocall/web/css/videocall-video-interface.css
@@ -990,3 +990,11 @@ video#local {
 	cursor: pointer;
 	font-size: 2rem;
 }
+
+.videocall-setting-grid-item {
+    display: grid;
+    background: var(--saito-background-color);
+    color: var(--saito-font-color);
+    padding: 2rem;
+    font-size: 1.75rem;
+}


### PR DESCRIPTION
- Change the settings menu to "Layout" and change the icon to the grid icon
- Add a new "Settings" menu that opens the menu available through "Module settings" (which should be removed from the settings menu)
- Make "Screen Share" it's own icon next to broadcast and record
- Change the title of the old settings menu to 'Layout' and update the HTML of the options to match the standard modal menus. (We want to be able to update the theme universally and update all overlay menus)

![Screenshot from 2024-04-05 06-31-31](https://github.com/SaitoTech/saito-lite-rust/assets/104337801/52aa8b8d-35b3-499d-a71a-49ba64a9fe3a)
