### PR TITLE
Fix in-game transfer polling

### DIFF
--- a/lib/templates/cryptomodule.js
+++ b/lib/templates/cryptomodule.js
@@ -485,4 +485,13 @@ CryptoModule.prototype.returnWithdrawalFeeForAddress = function (
  */
 CryptoModule.prototype.validateAddress = async function(address, ticker) { return true; }
 
+/**
+ * return utxo
+ * @abstract
+ * @param {string} address to validate
+ * @param {string} ticker to for selected crypto
+ * @return {boolean} true/false
+ */
+CryptoModule.prototype.returnUtxo = async function(state = 'unspent', limit = 1000, order = 'DESC') { return true; }
+
 module.exports = CryptoModule;

--- a/mods/mixin/lib/mixinmodule.js
+++ b/mods/mixin/lib/mixinmodule.js
@@ -343,7 +343,7 @@ class MixinModule extends CryptoModule {
 		//snapshot_datetime:  Mon Feb 12 2024 16:31:44 GMT+0500 (Pakistan Standard Time)
 		//mixinmodule.js:454 received_datetime:  Sun Sep 20 56111 06:01:14 GMT+0500 (Pakistan Standard Time)
 
-		let status = await this.mixin.fetchUtxo('unspent', 1000, 'DESC', (d) => {
+		let status = await this.mixin.fetchUtxo('unspent', 100000, 'DESC', (d) => {
 
 			console.log('utxo: ', d);
 

--- a/mods/mixin/mixin.js
+++ b/mods/mixin/mixin.js
@@ -136,7 +136,7 @@ class Mixin extends ModTemplate {
       let pc = await this.app.wallet.returnPreferredCryptoTicker();
       if (mixin_self.account_created !== 0 || (pc !== "SAITO" && pc !== "")) {
         if (crypto_module.returnIsActivated()) {
-          await this.fetchSafeUtxo();
+          await this.fetchSafeUtxoBalance();
         }
       }
     }
@@ -384,7 +384,7 @@ class Mixin extends ModTemplate {
     }
   }
 
-  async fetchSafeUtxo(asset_id){
+  async fetchSafeUtxoBalance(asset_id){
     try {
       let user = MixinApi({
         keystore: {
@@ -437,6 +437,35 @@ class Mixin extends ModTemplate {
       }
     } catch(err) {
       console.error("ERROR: Mixin error fetch safe snapshots: " + err);
+      return false;
+    }
+  }
+
+  async fetchUtxo(state = 'unspent', limit = 1000, order = 'DESC', callback = null){
+    try {
+      let user = MixinApi({
+        keystore: {
+          app_id: this.mixin.user_id,
+          session_id: this.mixin.session_id,
+          pin_token_base64: this.mixin.tip_key_base64,
+          session_private_key: this.mixin.session_seed
+        },
+      });
+
+      let params = {
+//        limit: limit,
+        state: state,
+        order: order,
+      };
+
+      let utxo_list = await user.utxo.safeOutputs(params);
+      console.log(`utxo_list ${state}:///`, utxo_list);
+
+      if (callback){
+        return callback(utxo_list);  
+      }
+    } catch(err) {
+      console.error("ERROR: Mixin error return utxo: " + err);
       return false;
     }
   }

--- a/mods/mixin/mixin.js
+++ b/mods/mixin/mixin.js
@@ -441,7 +441,7 @@ class Mixin extends ModTemplate {
     }
   }
 
-  async fetchUtxo(state = 'unspent', limit = 1000, order = 'DESC', callback = null){
+  async fetchUtxo(state = 'unspent', limit = 100000, order = 'DESC', callback = null){
     try {
       let user = MixinApi({
         keystore: {
@@ -453,7 +453,7 @@ class Mixin extends ModTemplate {
       });
 
       let params = {
-//        limit: limit,
+        limit: limit,
         state: state,
         order: order,
       };


### PR DESCRIPTION
Using utxo instead of snapshots for verifing payment received after end of round/end of game.

Currently we arent able to fetch utxo in descending order so I have set a very high limit of 100000 on ascending order records.
Have notified mixin team about this issue.