### PR TITLE
Arcade redesign

### DIFF
--- a/lib/templates/gametemplate.js
+++ b/lib/templates/gametemplate.js
@@ -514,6 +514,11 @@ try {
     access the game properties to render properly
     */
 		if (type == 'arcade-games') {
+
+			if (this.sort_priority == undefined) {
+				this.sort_priority = (this?.status) ? -1 : 0;
+			}
+
 			let obj = {};
 			obj.image = this.returnImage();
 			obj.banner = this.returnBanner();
@@ -652,6 +657,7 @@ try {
 			this.app.options.gameprefs.random = this.app.crypto.generateKeys();
 			this.app.storage.saveOptions();
 		}
+
 
 		this.initializeQueueCommands(); // Define standard queue commands
 

--- a/mods/arcade/arcade.js
+++ b/mods/arcade/arcade.js
@@ -96,6 +96,11 @@ class Arcade extends ModTemplate {
 				this.affix_callbacks_to.push(game_mod.name);
 			});
 
+
+		this.arcade_games = this.arcade_games.sort((a, b) => {
+			return (b.sort_priority - a.sort_priority);
+		});
+
 		this.games['mine'] = [];
 		this.games['open'] = [];
 

--- a/mods/arcade/arcade.js
+++ b/mods/arcade/arcade.js
@@ -96,9 +96,33 @@ class Arcade extends ModTemplate {
 				this.affix_callbacks_to.push(game_mod.name);
 			});
 
+		if (!app.options.arcade){
+			app.options.arcade = {};
+		}
 
+
+		// 
+		// Maybe good, maybe not... Only sorts on fresh load...
+		//
 		this.arcade_games = this.arcade_games.sort((a, b) => {
-			return (b.sort_priority - a.sort_priority);
+			//Default sorting 1, 0, -1
+			let b_count = b.sort_priority;
+			let a_count = a.sort_priority;
+
+			if (app.options.arcade?.last_game == b.name){
+				return 1;
+			}
+
+			//Add user behavior metrics
+			if (app.options.arcade[b.name]){
+				b_count += 2*app.options.arcade[b.name];
+			}
+
+			if (app.options.arcade[a.name]){
+				a_count += 2*app.options.arcade[a.name];
+			}
+
+			return (b_count - a_count);
 		});
 
 		this.games['mine'] = [];
@@ -1326,6 +1350,14 @@ class Arcade extends ModTemplate {
 		// If I am a player in the game, let's start it initializing
 		//
 		if (txmsg.players.includes(this.publicKey)) {
+
+			if (!this.app.options.arcade[txmsg.game]){
+				this.app.options.arcade[txmsg.game] = 0;
+			}
+			this.app.options.arcade[txmsg.game]++;
+
+			this.app.options.arcade.last_game = txmsg.game;
+
 			this.app.connection.emit('arcade-game-initialize-render-request', txmsg.game_id);
 
 			if (this.app.BROWSER == 1 && txmsg.players.length > 1) {

--- a/mods/arcade/arcade.js
+++ b/mods/arcade/arcade.js
@@ -396,6 +396,10 @@ class Arcade extends ModTemplate {
 		if (qs === '.redsquare-sidebar') {
 			return true;
 		}
+		if (qs === '.arcade-sidebar') {
+			return true;
+		}
+
 		return qs == '.league-overlay-games-list';
 	}
 
@@ -403,14 +407,14 @@ class Arcade extends ModTemplate {
 	// render components into other modules on-request
 	//
 	async renderInto(qs) {
-		if (qs == '.redsquare-sidebar') {
+		if (qs == '.redsquare-sidebar' || qs == ".arcade-sidebar") {
 			if (!this.renderIntos[qs]) {
 				this.styles = ['/arcade/style.css'];
 				this.renderIntos[qs] = [];
 				let obj = new InviteManager(
 					this.app,
 					this,
-					'.redsquare-sidebar'
+					qs
 				);
 				obj.type = 'short';
 				this.renderIntos[qs].push(obj);

--- a/mods/arcade/arcade.js
+++ b/mods/arcade/arcade.js
@@ -379,7 +379,7 @@ class Arcade extends ModTemplate {
 			'chat-manager'
 		)) {
 			let cm = mod.respondTo('chat-manager');
-			cm.container = '.saito-sidebar.left';
+			cm.container = '.saito-sidebar.right';
 			cm.render_manager_to_screen = 1;
 			this.addComponent(cm);
 		}

--- a/mods/arcade/lib/invite-manager.js
+++ b/mods/arcade/lib/invite-manager.js
@@ -4,6 +4,7 @@ const JSON = require('json-bigint');
 const ArcadeInitializer = require('./main/initializer');
 const SaitoOverlay = require('./../../../lib/saito/ui/saito-overlay/saito-overlay');
 const JoinGameOverlay = require('./overlays/join-game');
+const GameSlider = require('./game-slider');
 
 class InviteManager {
 	constructor(app, mod, container = '') {
@@ -12,6 +13,8 @@ class InviteManager {
 		this.container = container;
 		this.name = 'InviteManager';
 		this.type = 'short';
+
+		this.slider = new GameSlider(this.app, this.mod, ".invite-manager");
 
 		// For filtering which games get displayed
 		// We may want to only display one type of game invite, so overwrite this before render()
@@ -129,6 +132,8 @@ class InviteManager {
 			);
 		}
 
+		let rendered_content = false;
+
 		for (let list of this.lists) {
 			if (this.list === 'all' || this.list === list) {
 				if (!this.mod.games[list]) {
@@ -186,8 +191,13 @@ class InviteManager {
 						}
 					}
 					newInvite.render();
+					rendered_content = true;
 				}
 			}
+		}
+
+		if (!rendered_content){
+			this.slider.render();
 		}
 
 		this.attachEvents();

--- a/mods/arcade/lib/main/main.js
+++ b/mods/arcade/lib/main/main.js
@@ -3,7 +3,7 @@ const ArcadeMainTemplate = require('./main.template');
 const ArcadeInitializer = require('./initializer');
 
 class ArcadeMain {
-	constructor(app, mod, container = '') {
+	constructor(app, mod, container = 'body') {
 		this.app = app;
 		this.mod = mod;
 
@@ -85,11 +85,11 @@ class ArcadeMain {
 
 
 		Array.from(
-			document.querySelectorAll('.arcade-game-selector-game .launch-league')
+			document.querySelectorAll('.arcade-game-selector-game')
 		).forEach((game) => {
 			game.onclick = (e) => {
 				e.stopPropagation();
-				let modname = e.currentTarget.getAttribute('data-id');
+				let modname = e.currentTarget.getAttribute('data-league');
 
 				this.app.browser.logMatomoEvent(
 					'LeagueOverlay',
@@ -105,26 +105,6 @@ class ArcadeMain {
 			};
 		});
 
-		Array.from(
-			document.querySelectorAll('.arcade-game-selector-game .launch-wizard')
-		).forEach((game) => {
-			game.onclick = (e) => {
-				e.stopPropagation();
-				let modname = e.currentTarget.getAttribute('data-id');
-
-				this.app.browser.logMatomoEvent(
-					'GameWizard',
-					'GameSelector',
-					modname
-				);
-
-				this.app.connection.emit(
-						'arcade-launch-game-wizard',
-						{game: modname}
-				);
-
-			};
-		});
 
 	}
 }

--- a/mods/arcade/lib/main/main.js
+++ b/mods/arcade/lib/main/main.js
@@ -6,14 +6,15 @@ class ArcadeMain {
 	constructor(app, mod, container = 'body') {
 		this.app = app;
 		this.mod = mod;
-
-
+		this.container = container;
 
 		//
 		// load init page
 		//
 		app.connection.on('arcade-game-initialize-render-request', (game_id) => {
 			document.querySelector('.arcade-main').innerHTML = '';
+			document.querySelector('.arcade-main').classList.remove("can-scroll-up");
+			document.querySelector('.arcade-main').classList.remove("can-scroll-down");
 
 			if (document.getElementById('saito-container')) {
 				document.getElementById('saito-container').scrollTop = 0;
@@ -60,7 +61,7 @@ class ArcadeMain {
 	attachEvents() {
 
 		let gameListContainerAlt = document.querySelector(".arcade-main");
-		let gameListContainer = document.querySelector(".arcade-game-filter-list")
+		let gameListContainer = document.querySelector(".arcade-main")
 
 		const intersectionObserver = new IntersectionObserver((entries) => {
 		  entries.forEach(entry => {
@@ -89,18 +90,33 @@ class ArcadeMain {
 		).forEach((game) => {
 			game.onclick = (e) => {
 				e.stopPropagation();
-				let modname = e.currentTarget.getAttribute('data-league');
+				let league_id = e.currentTarget.getAttribute('data-league');
 
-				this.app.browser.logMatomoEvent(
-					'LeagueOverlay',
-					'GameSelector',
-					modname
-				);
+				if (league_id){
+					this.app.browser.logMatomoEvent(
+						'LeagueOverlay',
+						'GameSelector',
+						league_id
+					);
 
-				this.app.connection.emit(
-						'league-overlay-render-request',
+					this.app.connection.emit(
+							'league-overlay-render-request',
+							league_id
+					);			
+				}else{
+					let modname = e.currentTarget.getAttribute('data-id');
+					this.app.browser.logMatomoEvent(
+						'GameWizard',
+						'GameSelector',
 						modname
-				);
+					);
+
+					this.app.connection.emit(
+							'arcade-launch-game-wizard',
+							{game: modname}
+					);			
+
+				}
 
 			};
 		});

--- a/mods/arcade/lib/main/main.js
+++ b/mods/arcade/lib/main/main.js
@@ -12,6 +12,7 @@ class ArcadeMain {
 		// load init page
 		//
 		app.connection.on('arcade-game-initialize-render-request', (game_id) => {
+			this.intersectionObserver.disconnect();
 			document.querySelector('.arcade-main').innerHTML = '';
 			document.querySelector('.arcade-main').classList.remove("can-scroll-up");
 			document.querySelector('.arcade-main').classList.remove("can-scroll-down");
@@ -35,6 +36,26 @@ class ArcadeMain {
 		app.connection.on('rerender-whole-arcade', () => {
 			this.render();
 		});
+
+		this.intersectionObserver = new IntersectionObserver((entries) => {
+		  let gameListContainer = document.querySelector(".arcade-main");			
+		  entries.forEach(entry => {
+			  if (entry.intersectionRatio <= 0) {
+			  	if (entry.target.id == "top-of-game-list"){
+			  		gameListContainer.classList.add("can-scroll-up");
+			  	}else{
+			  		gameListContainer.classList.add("can-scroll-down");
+			  	}
+			  }else{
+			  	if (entry.target.id == "top-of-game-list"){
+			  		gameListContainer.classList.remove("can-scroll-up");
+			  	}else{
+			  		gameListContainer.classList.remove("can-scroll-down");
+			  	}
+			  }
+		  });
+		});
+
 	}
 
 	async render() {
@@ -60,30 +81,9 @@ class ArcadeMain {
 
 	attachEvents() {
 
-		let gameListContainerAlt = document.querySelector(".arcade-main");
-		let gameListContainer = document.querySelector(".arcade-main")
-
-		const intersectionObserver = new IntersectionObserver((entries) => {
-		  entries.forEach(entry => {
-			  if (entry.intersectionRatio <= 0) {
-			  	if (entry.target.id == "top-of-game-list"){
-			  		gameListContainer.classList.add("can-scroll-up");
-			  	}else{
-			  		gameListContainerAlt.classList.add("can-scroll-down");
-			  	}
-			  }else{
-			  	if (entry.target.id == "top-of-game-list"){
-			  		gameListContainer.classList.remove("can-scroll-up");
-			  	}else{
-			  		gameListContainerAlt.classList.remove("can-scroll-down");
-			  	}
-			  }
-		  });
-		});
 		// start observing
-		intersectionObserver.observe(document.getElementById("top-of-game-list"));
-		intersectionObserver.observe(document.getElementById("bottom-of-game-list"));
-
+		this.intersectionObserver.observe(document.getElementById("top-of-game-list"));
+		this.intersectionObserver.observe(document.getElementById("bottom-of-game-list"));
 
 		Array.from(
 			document.querySelectorAll('.arcade-game-selector-game')

--- a/mods/arcade/lib/main/main.js
+++ b/mods/arcade/lib/main/main.js
@@ -1,7 +1,6 @@
 const JSON = require('json-bigint');
 const ArcadeMainTemplate = require('./main.template');
 const ArcadeInitializer = require('./initializer');
-const CentralPanel = require('../overlays/game-selector.template.js');
 
 class ArcadeMain {
 	constructor(app, mod, container = '') {
@@ -14,7 +13,7 @@ class ArcadeMain {
 		// load init page
 		//
 		app.connection.on('arcade-game-initialize-render-request', (game_id) => {
-			document.querySelector('.arcade-central-panel').innerHTML = '';
+			document.querySelector('.arcade-main').innerHTML = '';
 
 			if (document.getElementById('saito-container')) {
 				document.getElementById('saito-container').scrollTop = 0;
@@ -23,7 +22,7 @@ class ArcadeMain {
 			let initializer = new ArcadeInitializer(
 				this.app,
 				this.mod,
-				'.arcade-central-panel'
+				'.arcade-main'
 			);
 
 			this.mod.is_game_initializing = true;
@@ -40,17 +39,15 @@ class ArcadeMain {
 	async render() {
 		if (document.querySelector('.saito-container')) {
 			this.app.browser.replaceElementBySelector(
-				ArcadeMainTemplate(),
+				ArcadeMainTemplate(this.app, this.mod),
 				'.saito-container'
 			);
 		} else {
 			this.app.browser.addElementToSelector(
-				ArcadeMainTemplate(),
+				ArcadeMainTemplate(this.app, this.mod),
 				this.container
 			);
 		}
-
-		this.app.browser.addElementToId(CentralPanel(this.app, this.mod), "arcade-central-panel");
 
 		//
 		// invite manager

--- a/mods/arcade/lib/main/main.js
+++ b/mods/arcade/lib/main/main.js
@@ -1,30 +1,20 @@
 const JSON = require('json-bigint');
 const ArcadeMainTemplate = require('./main.template');
-const ArcadeMenu = require('./menu');
-const GameSlider = require('../game-slider');
 const ArcadeInitializer = require('./initializer');
-const SaitoSidebar = require('./../../../../lib/saito/ui/saito-sidebar/saito-sidebar');
+const CentralPanel = require('../overlays/game-selector.template.js');
 
 class ArcadeMain {
 	constructor(app, mod, container = '') {
 		this.app = app;
 		this.mod = mod;
 
-		//
-		// left sidebar
-		//
-		this.sidebar = new SaitoSidebar(this.app, this.mod, '.saito-container');
-		this.sidebar.align = 'nope';
-		this.menu = new ArcadeMenu(this.app, this.mod, '.saito-sidebar.left');
-		this.sidebar.addComponent(this.menu);
-		this.slider = new GameSlider(this.app, this.mod, '.arcade-game-slider');
+
 
 		//
 		// load init page
 		//
 		app.connection.on('arcade-game-initialize-render-request', (game_id) => {
 			document.querySelector('.arcade-central-panel').innerHTML = '';
-			this.slider.hide();
 
 			if (document.getElementById('saito-container')) {
 				document.getElementById('saito-container').scrollTop = 0;
@@ -60,12 +50,7 @@ class ArcadeMain {
 			);
 		}
 
-		await this.sidebar.render();
-
-		//
-		// slider
-		//
-		await this.slider.render();
+		this.app.browser.addElementToId(CentralPanel(this.app, this.mod), "arcade-central-panel");
 
 		//
 		// invite manager

--- a/mods/arcade/lib/main/main.js
+++ b/mods/arcade/lib/main/main.js
@@ -50,52 +50,82 @@ class ArcadeMain {
 		}
 
 		//
-		// invite manager
+		// invites box modules
 		//
-		await this.app.modules.renderInto('.arcade-invites-box');
-
-		//
-		// appspace modules
-		//
-		await this.app.modules.renderInto('.arcade-leagues');
+		await this.app.modules.renderInto('.arcade-sidebar');
 
 		this.attachEvents();
 	}
 
 	attachEvents() {
-		/*
 
-		const scrollableElement = document.querySelector('.saito-container');
-		const sidebar = document.querySelector('.saito-sidebar.right');
-		let scrollTop = 0;
-		let stop = 0;
+		let gameListContainerAlt = document.querySelector(".arcade-main");
+		let gameListContainer = document.querySelector(".arcade-game-filter-list")
 
-		scrollableElement.addEventListener('scroll', (e) => {
-			if (window.innerHeight - 150 < sidebar.clientHeight) {
-				if (scrollTop < scrollableElement.scrollTop) {
-					stop =
-						window.innerHeight -
-						sidebar.clientHeight +
-						scrollableElement.scrollTop;
-					if (
-						scrollableElement.scrollTop + window.innerHeight >
-						sidebar.clientHeight
-					) {
-						sidebar.style.top = stop + 'px';
-					}
-				} else {
-					if (stop > scrollableElement.scrollTop) {
-						stop = scrollableElement.scrollTop;
-						sidebar.style.top = stop + 'px';
-					}
-				}
-			} else {
-				stop = scrollableElement.scrollTop;
-				sidebar.style.top = stop + 'px';
-			}
-			scrollTop = scrollableElement.scrollTop;
+		const intersectionObserver = new IntersectionObserver((entries) => {
+		  entries.forEach(entry => {
+			  if (entry.intersectionRatio <= 0) {
+			  	if (entry.target.id == "top-of-game-list"){
+			  		gameListContainer.classList.add("can-scroll-up");
+			  	}else{
+			  		gameListContainerAlt.classList.add("can-scroll-down");
+			  	}
+			  }else{
+			  	if (entry.target.id == "top-of-game-list"){
+			  		gameListContainer.classList.remove("can-scroll-up");
+			  	}else{
+			  		gameListContainerAlt.classList.remove("can-scroll-down");
+			  	}
+			  }
+		  });
 		});
-		*/
+		// start observing
+		intersectionObserver.observe(document.getElementById("top-of-game-list"));
+		intersectionObserver.observe(document.getElementById("bottom-of-game-list"));
+
+
+		Array.from(
+			document.querySelectorAll('.arcade-game-selector-game .launch-league')
+		).forEach((game) => {
+			game.onclick = (e) => {
+				e.stopPropagation();
+				let modname = e.currentTarget.getAttribute('data-id');
+
+				this.app.browser.logMatomoEvent(
+					'LeagueOverlay',
+					'GameSelector',
+					modname
+				);
+
+				this.app.connection.emit(
+						'league-overlay-render-request',
+						modname
+				);
+
+			};
+		});
+
+		Array.from(
+			document.querySelectorAll('.arcade-game-selector-game .launch-wizard')
+		).forEach((game) => {
+			game.onclick = (e) => {
+				e.stopPropagation();
+				let modname = e.currentTarget.getAttribute('data-id');
+
+				this.app.browser.logMatomoEvent(
+					'GameWizard',
+					'GameSelector',
+					modname
+				);
+
+				this.app.connection.emit(
+						'arcade-launch-game-wizard',
+						{game: modname}
+				);
+
+			};
+		});
+
 	}
 }
 

--- a/mods/arcade/lib/main/main.template.js
+++ b/mods/arcade/lib/main/main.template.js
@@ -1,34 +1,57 @@
 module.exports = ArcadeMainTemplate = (app, mod) => {
 
   let games_menu = '';
+  let leagues = [];
+
+  try{
+    let league_obj = app.modules.returnFirstRespondTo("leagues-for-arcade");  
+    leagues = league_obj.leagues;
+  }catch (err){
+    console.warn("no league module installled");
+  }
+  
 
   for (let i = 0; i < mod.arcade_games.length; i++) {
     let game_mod = mod.arcade_games[i];
       games_menu += `
        <div id="${game_mod.name}" class="arcade-game-selector-game" data-id="${ game_mod.name }">
-       <div class="arcade-game-selector-game-image"><img src="${game_mod.respondTo('arcade-games').image}" /></div>
-         <div class="arcade-game-selector-game-title">${game_mod.returnName()}</div>
-       </div>
-      `;
+         <div class="arcade-game-selector-game-image"><img src="${game_mod.respondTo('arcade-games').image}" /></div>
+         <div class="arcade-game-selector-game-title"><span>${game_mod.returnName()}</span>`
+     if (game_mod?.can_bet){
+        games_menu += `<i class="fa-solid fa-coins game-crypto-enabled-icon" title="you can stake web3 crypto on this game"></i>`;  
+     }
+       games_menu += `</div>
+        <div class="game-selector-card-buttons">
+          <div id="launch-wizard" class="saito-button-primary launch-wizard" data-id="${ game_mod.name }">play</div>
+       `;
+
+       let lid = app.crypto.hash(game_mod.returnName());
+       for (let league of leagues){
+          if (league.id == lid){
+            games_menu += `<div id="lauch-league" class="saito-button-primary launch-league" data-id="${lid}">info</div>`;
+            break;  
+          }
+       }       
+
+       games_menu +='</div></div>';
   }
 
 	return `
     <div id="saito-container" class="saito-container arcade-container">
       <div id="arcade-main" class="saito-main arcade-main">
-        <div id="arcade-invites-box" class="arcade-invites-box"></div>
         <div id="arcade-game-filter-list" class="arcade-game-filter-list">
-          <div id="all-games" class="game-filter-item">all games</div>
+          <!--div id="all-games" class="game-filter-item">all games</div>
           <div id="all-games" class="game-filter-item">card games</div>
           <div id="all-games" class="game-filter-item">board games</div>
-          <div id="all-games" class="game-filter-item">one player games</div>
+          <div id="all-games" class="game-filter-item">one player games</div-->
         </div>
-        <div id="arcade-central-panel" class="arcade-central-panel">
+        <div id="arcade-central-panel" class="arcade-central-panel hide-scrollbar">
+          <div class="intersection-anchor" id="top-of-game-list"></div>
           ${games_menu}
-	      </div>
+	        <div class="intersection-anchor" id="bottom-of-game-list"></div>
+        </div>
       </div>
-      <div class="saito-sidebar right">
-        <div id="arcade-leagues" class="arcade-leagues"></div>
-      </div>
+      <div class="saito-sidebar right arcade-sidebar"></div>
     </div>
   `;
 

--- a/mods/arcade/lib/main/main.template.js
+++ b/mods/arcade/lib/main/main.template.js
@@ -1,11 +1,16 @@
 module.exports = ArcadeMainTemplate = () => {
 	return `
     <div id="saito-container" class="saito-container arcade-container">
-      <div class="saito-sidebar left"></div>
       <div id="arcade-main" class="saito-main arcade-main">
-        <div id="arcade-game-slider" class="arcade-game-slider"></div>
+        <div id="arcade-invites-box" class="arcade-invites-box"></div>
         <div id="arcade-central-panel" class="arcade-central-panel">
-          <div id="arcade-invites-box" class="arcade-invites-box"></div>
+          <div id="arcade-game-filter-list" class="arcade-game-filter-list">
+            <div id="all-games" class="game-filter-item">all games</div>
+            <div id="all-games" class="game-filter-item">card games</div>
+            <div id="all-games" class="game-filter-item">board games</div>
+            <div id="all-games" class="game-filter-item">one player games</div>
+          </div>
+
 	      </div>
       </div>
       <div class="saito-sidebar right">

--- a/mods/arcade/lib/main/main.template.js
+++ b/mods/arcade/lib/main/main.template.js
@@ -1,26 +1,29 @@
 module.exports = ArcadeMainTemplate = (app, mod) => {
 
   let games_menu = '';
-  let leagues = [];
+  /*let leagues = [];
 
   try{
     let league_obj = app.modules.returnFirstRespondTo("leagues-for-arcade");  
     leagues = league_obj.leagues;
   }catch (err){
     console.warn("no league module installled");
-  }
+  }*/
   
 
   for (let i = 0; i < mod.arcade_games.length; i++) {
     let game_mod = mod.arcade_games[i];
+
+    let lid = app.crypto.hash(game_mod.returnName());
+
       games_menu += `
-       <div id="${game_mod.name}" class="arcade-game-selector-game" data-id="${ game_mod.name }">
+       <div id="${game_mod.name}" class="arcade-game-selector-game" data-id="${ game_mod.name }" data-league="${lid}">
          <div class="arcade-game-selector-game-image"><img src="${game_mod.respondTo('arcade-games').image}" /></div>
          <div class="arcade-game-selector-game-title"><span>${game_mod.returnName()}</span>`
      if (game_mod?.can_bet){
         games_menu += `<i class="fa-solid fa-coins game-crypto-enabled-icon" title="you can stake web3 crypto on this game"></i>`;  
      }
-       games_menu += `</div>
+       /*games_menu += `</div>
         <div class="game-selector-card-buttons">
           <div id="launch-wizard" class="saito-button-primary launch-wizard" data-id="${ game_mod.name }">play</div>
        `;
@@ -31,7 +34,7 @@ module.exports = ArcadeMainTemplate = (app, mod) => {
             games_menu += `<div id="lauch-league" class="saito-button-primary launch-league" data-id="${lid}">info</div>`;
             break;  
           }
-       }       
+       } */      
 
        games_menu +='</div></div>';
   }
@@ -51,7 +54,9 @@ module.exports = ArcadeMainTemplate = (app, mod) => {
 	        <div class="intersection-anchor" id="bottom-of-game-list"></div>
         </div>
       </div>
-      <div class="saito-sidebar right arcade-sidebar"></div>
+      <div class="saito-sidebar right arcade-sidebar">
+        <div class='saito-announcement'>The Saito Arcade is a launch pad for a variety of peer-to-peer games hosted on Saito's unique blockchain. Games here integrate other features of the Saito Network, such as instant messaging, web3 cryptocurrency staking, and voice and video calling tools. Play any game to automatically join the leaderboard. Register a free username so that your opponents can remember who kicked their butt. Have fun!</div>
+      </div>
     </div>
   `;
 

--- a/mods/arcade/lib/main/main.template.js
+++ b/mods/arcade/lib/main/main.template.js
@@ -1,16 +1,29 @@
-module.exports = ArcadeMainTemplate = () => {
+module.exports = ArcadeMainTemplate = (app, mod) => {
+
+  let games_menu = '';
+
+  for (let i = 0; i < mod.arcade_games.length; i++) {
+    let game_mod = mod.arcade_games[i];
+      games_menu += `
+       <div id="${game_mod.name}" class="arcade-game-selector-game" data-id="${ game_mod.name }">
+       <div class="arcade-game-selector-game-image"><img src="${game_mod.respondTo('arcade-games').image}" /></div>
+         <div class="arcade-game-selector-game-title">${game_mod.returnName()}</div>
+       </div>
+      `;
+  }
+
 	return `
     <div id="saito-container" class="saito-container arcade-container">
       <div id="arcade-main" class="saito-main arcade-main">
         <div id="arcade-invites-box" class="arcade-invites-box"></div>
+        <div id="arcade-game-filter-list" class="arcade-game-filter-list">
+          <div id="all-games" class="game-filter-item">all games</div>
+          <div id="all-games" class="game-filter-item">card games</div>
+          <div id="all-games" class="game-filter-item">board games</div>
+          <div id="all-games" class="game-filter-item">one player games</div>
+        </div>
         <div id="arcade-central-panel" class="arcade-central-panel">
-          <div id="arcade-game-filter-list" class="arcade-game-filter-list">
-            <div id="all-games" class="game-filter-item">all games</div>
-            <div id="all-games" class="game-filter-item">card games</div>
-            <div id="all-games" class="game-filter-item">board games</div>
-            <div id="all-games" class="game-filter-item">one player games</div>
-          </div>
-
+          ${games_menu}
 	      </div>
       </div>
       <div class="saito-sidebar right">
@@ -18,4 +31,5 @@ module.exports = ArcadeMainTemplate = () => {
       </div>
     </div>
   `;
+
 };

--- a/mods/arcade/lib/main/main.template.js
+++ b/mods/arcade/lib/main/main.template.js
@@ -1,20 +1,23 @@
 module.exports = ArcadeMainTemplate = (app, mod) => {
 
   let games_menu = '';
-  /*let leagues = [];
+  
+  let league = null;
 
   try{
-    let league_obj = app.modules.returnFirstRespondTo("leagues-for-arcade");  
-    leagues = league_obj.leagues;
+    league = app.modules.returnFirstRespondTo("leagues-for-arcade");  
   }catch (err){
     console.warn("no league module installled");
-  }*/
+  }
   
 
   for (let i = 0; i < mod.arcade_games.length; i++) {
     let game_mod = mod.arcade_games[i];
 
     let lid = app.crypto.hash(game_mod.returnName());
+    if (!league?.returnLeague(lid)){
+      lid = "";
+    }
 
       games_menu += `
        <div id="${game_mod.name}" class="arcade-game-selector-game" data-id="${ game_mod.name }" data-league="${lid}">
@@ -23,31 +26,13 @@ module.exports = ArcadeMainTemplate = (app, mod) => {
      if (game_mod?.can_bet){
         games_menu += `<i class="fa-solid fa-coins game-crypto-enabled-icon" title="you can stake web3 crypto on this game"></i>`;  
      }
-       /*games_menu += `</div>
-        <div class="game-selector-card-buttons">
-          <div id="launch-wizard" class="saito-button-primary launch-wizard" data-id="${ game_mod.name }">play</div>
-       `;
 
-       let lid = app.crypto.hash(game_mod.returnName());
-       for (let league of leagues){
-          if (league.id == lid){
-            games_menu += `<div id="lauch-league" class="saito-button-primary launch-league" data-id="${lid}">info</div>`;
-            break;  
-          }
-       } */      
-
-       games_menu +='</div></div>';
+     games_menu +='</div></div>';
   }
 
 	return `
     <div id="saito-container" class="saito-container arcade-container">
       <div id="arcade-main" class="saito-main arcade-main">
-        <div id="arcade-game-filter-list" class="arcade-game-filter-list">
-          <!--div id="all-games" class="game-filter-item">all games</div>
-          <div id="all-games" class="game-filter-item">card games</div>
-          <div id="all-games" class="game-filter-item">board games</div>
-          <div id="all-games" class="game-filter-item">one player games</div-->
-        </div>
         <div id="arcade-central-panel" class="arcade-central-panel hide-scrollbar">
           <div class="intersection-anchor" id="top-of-game-list"></div>
           ${games_menu}

--- a/mods/arcade/lib/overlays/game-selector.template.js
+++ b/mods/arcade/lib/overlays/game-selector.template.js
@@ -7,12 +7,8 @@ module.exports = GameSelectorTemplate = (app, mod, game_selector = null) => {
 		if (game_selector?.obj?.publicKey && game_mod.minPlayers == 1) {
 		} else {
 			games_menu += `
-       <div id="${game_mod.name}" class="arcade-game-selector-game" data-id="${
-	game_mod.name
-}">
-     	 <div class="arcade-game-selector-game-image"><img src="${
-	game_mod.respondTo('arcade-games').image
-}" /></div>
+       <div id="${game_mod.name}" class="arcade-game-selector-game" data-id="${	game_mod.name	}">
+     	 <div class="arcade-game-selector-game-image"><img src="${game_mod.respondTo('arcade-games').image}" /></div>
       	 <div class="arcade-game-selector-game-title">${game_mod.returnName()}</div>
        </div>
       `;

--- a/mods/arcade/lib/overlays/game-selector.template.js
+++ b/mods/arcade/lib/overlays/game-selector.template.js
@@ -1,10 +1,10 @@
-module.exports = GameSelectorTemplate = (app, mod, game_selector) => {
+module.exports = GameSelectorTemplate = (app, mod, game_selector = null) => {
 	let games_menu = '';
 
 	for (let i = 0; i < mod.arcade_games.length; i++) {
 		let game_mod = mod.arcade_games[i];
 
-		if (game_selector.obj.publicKey != null && game_mod.minPlayers == 1) {
+		if (game_selector?.obj?.publicKey && game_mod.minPlayers == 1) {
 		} else {
 			games_menu += `
        <div id="${game_mod.name}" class="arcade-game-selector-game" data-id="${

--- a/mods/arcade/web/css/arcade-base.css
+++ b/mods/arcade/web/css/arcade-base.css
@@ -1,31 +1,16 @@
-.arcade-container{
+
+.arcade-container.saito-container{
+	grid-template-columns: auto 30rem;
+	padding: 0 calc((100vw - var(--saito-width)) / 2);
 	column-gap: unset;
 }
 
-#saito-header {
-	background: var(--saito-arcade-header-background);
-	border-bottom: none;
-}
-
-.arcade-tab-container {
-	height: fit-content;
-	width: 100%;
-}
-
-.saito-header-hamburger-contents {
-	background: var(--saito-arcade-background);
-}
-
-.arcade-container.saito-container{
-	grid-template-columns: 1fr min-content;
-
-	padding: 0 calc((100vw - var(--saito-width)) / 4);
-}
-
+/* Filter buttons */
 .arcade-game-filter-list{
 	display: flex;
 	width: 100%;
 	align-items: center;
+	justify-content: flex-end;
 	gap: 2rem;
 }
 
@@ -35,6 +20,14 @@
 	border: 1px solid;
 }
 
+/* right sidebar*/ 
+.saito-sidebar.right{
+	grid-column: unset;
+	grid-row: unset;
+}
+
+
+/* main panel */ 
 .arcade-main {
 	display: flex;
 	flex-direction: column;
@@ -42,24 +35,6 @@
 	padding-top: 2rem;
 }
 
-.arcade-game-list-container {
-	max-height: 60%;
-	position: relative;
-}
-
-.arcade-menu {
-	max-height: calc(100% - 4rem);
-
-}
-
-/*button, .saito-button-primary, .saito-button-secondary:hover {*/
-.saito-button-secondary:hover {
-	background: var(--background-color-button-mod-arcade);
-}
-
-.saito-button-secondary {
-	color: var(--font-color-button-module);
-}
 
 .arcade-initializer {
 	text-align: center;
@@ -68,7 +43,7 @@
 	flex-direction: column;
 }
 
-.arcade-central-panel .arcade-initializer {
+.arcade-main .arcade-initializer {
 	height: calc(100vh - var(--saito-header-height) - 3rem);
 	padding-top: 5rem;
 	gap: 5rem;
@@ -85,10 +60,53 @@
 	margin: 3rem auto;
 }
 
-.arcade-central-panel h5 {
-	margin: 0 0 -1rem 0;
+
+.arcade-central-panel {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+	grid-gap: 1rem;
 }
 
+
+
+/*************************************
+ * Override saito-page-layout 
+ * to make arcade better on mobile
+**************************************/
+
+@media screen and (max-width: 900px) {
+	.arcade-container .saito-sidebar.right {
+		display: block;
+		visibility: visible;
+		position: unset;
+		grid-row: unset;
+		grid-column-start: unset;
+		padding: 1rem;
+	}
+	.arcade-container .saito-main {
+		margin: 0;
+	}
+	.arcade-container .saito-sidebar.right .saito-table-row {
+		padding: 1rem;
+	}
+	.arcade-container .saito-sidebar.right .saito-table-body {
+		grid-gap: 0.8rem;
+		font-size: 1.6rem;
+	}
+}
+
+
+
+/************ DEPRECATED ***************/
+.arcade-game-list-container {
+	max-height: 60%;
+	position: relative;
+}
+
+.arcade-menu {
+	max-height: calc(100% - 4rem);
+
+}
 
 /**************************
  * Fancy scrolling
@@ -148,35 +166,3 @@
   line-height: 4rem;
 }
 
-
-
-/*************************************
- * Override saito-page-layout 
- * to make arcade better on mobile
-**************************************/
-@media screen and (max-width: 1200px) {
-	.arcade-main{
-		margin-left: 1rem;
-	}
-}
-
-@media screen and (max-width: 900px) {
-	.arcade-container .saito-sidebar.right {
-		display: block;
-		visibility: visible;
-		position: unset;
-		grid-row: unset;
-		grid-column-start: unset;
-		padding: 1rem;
-	}
-	.arcade-container .saito-main {
-		margin: 0;
-	}
-	.arcade-container .saito-sidebar.right .saito-table-row {
-		padding: 1rem;
-	}
-	.arcade-container .saito-sidebar.right .saito-table-body {
-		grid-gap: 0.8rem;
-		font-size: 1.6rem;
-	}
-}

--- a/mods/arcade/web/css/arcade-base.css
+++ b/mods/arcade/web/css/arcade-base.css
@@ -16,6 +16,12 @@
 	background: var(--saito-arcade-background);
 }
 
+.arcade-container.saito-container{
+	grid-template-columns: 1fr min-content;
+
+	padding: 0 calc((100vw - var(--saito-width)) / 4);
+}
+
 .arcade-main {
 	display: flex;
 	flex-direction: column;

--- a/mods/arcade/web/css/arcade-base.css
+++ b/mods/arcade/web/css/arcade-base.css
@@ -22,6 +22,19 @@
 	padding: 0 calc((100vw - var(--saito-width)) / 4);
 }
 
+.arcade-game-filter-list{
+	display: flex;
+	width: 100%;
+	align-items: center;
+	gap: 2rem;
+}
+
+.game-filter-item{
+	padding: 1rem;
+	border-radius: 1.5rem;
+	border: 1px solid;
+}
+
 .arcade-main {
 	display: flex;
 	flex-direction: column;

--- a/mods/arcade/web/css/arcade-base.css
+++ b/mods/arcade/web/css/arcade-base.css
@@ -82,6 +82,10 @@
 }
 
 
+.arcade-sidebar .saito-announcement {
+	margin-bottom: 1rem;
+}
+
 
 /******************************************
  *  OVER WRITE Game Selector Overlay code
@@ -175,6 +179,11 @@
 	.arcade-central-panel {
 		grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 	}
+
+	.arcade-sidebar .saito-announcement {
+		display: none;
+	}
+
 }
 
 

--- a/mods/arcade/web/css/arcade-base.css
+++ b/mods/arcade/web/css/arcade-base.css
@@ -1,8 +1,13 @@
+:root{
+	--saito-width: 1500px;
+}
 
 .arcade-container.saito-container{
 	grid-template-columns: auto 30rem;
+	grid-template-rows: minmax(5px, 1fr);
 	padding: 0 calc((100vw - var(--saito-width)) / 2);
-	column-gap: unset;
+	padding-left: calc((100vw - var(--saito-width)) / 4);
+	overflow: hidden;
 }
 
 /* Filter buttons */
@@ -11,13 +16,15 @@
 	width: 100%;
 	align-items: center;
 	justify-content: flex-end;
-	gap: 2rem;
+	gap: 1rem;
+	position: relative;
 }
 
 .game-filter-item{
 	padding: 1rem;
-	border-radius: 1.5rem;
+	border-radius: 1rem;
 	border: 1px solid;
+	cursor: pointer;
 }
 
 /* right sidebar*/ 
@@ -29,12 +36,18 @@
 
 /* main panel */ 
 .arcade-main {
-	display: flex;
+	position: relative;
+	display: grid;
 	flex-direction: column;
 	row-gap: 1rem;
-	padding-top: 2rem;
+	padding: 1rem;
+	height: 100%;
+	grid-template-rows: min-content minmax(0, 1fr);
 }
 
+.arcade-scrollable-panel-container{
+	height: 100%;
+}
 
 .arcade-initializer {
 	text-align: center;
@@ -63,18 +76,78 @@
 
 .arcade-central-panel {
 	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+	grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
 	grid-gap: 1rem;
+	position: relative;
 }
 
 
+
+/******************************************
+ *  OVER WRITE Game Selector Overlay code
+ *****************************************/
+.arcade-central-panel .arcade-game-selector-game{
+	box-shadow: 0px 2px 4px var(--saito-bubble-shadow);
+	border-radius: 0.5rem;
+}
+
+.arcade-game-selector-game-image img{
+	border-radius: 0.5rem;
+}
+
+.arcade-central-panel .arcade-game-selector-game-title{
+	height: 5rem;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 0 1.5rem;
+	border-radius: 0.5rem 0.5rem 0 0;
+}
+
+.arcade-central-panel .arcade-game-selector-game-title span{
+	font-size: 2.4rem;
+	text-transform: unset;
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	flex: 1;
+}
+
+.game-selector-card-buttons {
+	position: absolute;
+	bottom: 0;
+	width: 100%;
+	height: 5rem;
+	display: flex;
+	align-items: center;
+	justify-content: space-around;
+}
+
+.game-selector-card-buttons .saito-button-primary {
+	min-width: 5rem;
+}
+
+.arcade-central-panel .arcade-game-selector-game:hover{
+	transform: none;
+	border-color: var(--saito-font-color-heavy);
+}
 
 /*************************************
  * Override saito-page-layout 
  * to make arcade better on mobile
 **************************************/
+@media screen and (max-width: 1200px){
+	.saito-floating-plus-btn{
+		display: none;
+	}
+}
+
 
 @media screen and (max-width: 900px) {
+	.saito-container.arcade-container{
+		grid-template-columns: 1fr;
+	}
+
 	.arcade-container .saito-sidebar.right {
 		display: block;
 		visibility: visible;
@@ -92,6 +165,15 @@
 	.arcade-container .saito-sidebar.right .saito-table-body {
 		grid-gap: 0.8rem;
 		font-size: 1.6rem;
+	}
+
+	.arcade-container .saito-sidebar.right .game-slider, 
+	.arcade-container .saito-sidebar.right .chat-manager{
+		display: none;
+	}
+
+	.arcade-central-panel {
+		grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 	}
 }
 
@@ -111,19 +193,32 @@
 /**************************
  * Fancy scrolling
 **************************/
-.arcade-game-list-container.can-scroll-down::before {
+
+#top-of-game-list{
+	position: absolute;
+	top: 5rem;
+}
+
+#bottom-of-game-list{
+	position: relative;
+	bottom: 0;
+}
+
+
+
+.can-scroll-down::before {
 	content: " ";
 	position: absolute;
 	bottom: 0;
 	left: 0;
 	width: 100%;
-	height: 6rem;
+	height: 8rem;
 	z-index: 5;
 	pointer-events: none;
     background: linear-gradient(180deg, transparent, var(--saito-background-color));
 } 
 
-.arcade-game-list-container.can-scroll-down:hover::after {
+.can-scroll-down:hover::after {
   font-family: FontAwesome;
   content: "\f0d7";
   position: absolute;
@@ -139,24 +234,24 @@
 }
 
 /*  "\f0d8"  */
-.arcade-menu.can-scroll-up::before {
+.can-scroll-up::before {
 	content: " ";
 	position: absolute;
-	bottom: top;
+	top: calc(100% + 1rem);
 	left: 0;
 	width: 100%;
-	height: 6rem;
+	height: 8rem;
 	z-index: 5;
 	pointer-events: none;
     background: linear-gradient(0deg, transparent, var(--saito-background-color));
 } 
 
-.arcade-menu.can-scroll-up:hover::after {
+.can-scroll-up:hover::after {
   font-family: FontAwesome;
   content: "\f0d8";
   position: absolute;
-  top: 4rem;
   color: var(--border-color-general-dividers-dark);
+  top: calc(100% + 1rem);
   font-size: 4rem;
   z-index: 999;
   text-align: center;

--- a/mods/arcade/web/css/arcade-base.css
+++ b/mods/arcade/web/css/arcade-base.css
@@ -37,12 +37,8 @@
 /* main panel */ 
 .arcade-main {
 	position: relative;
-	display: grid;
-	flex-direction: column;
-	row-gap: 1rem;
 	padding: 1rem;
 	height: 100%;
-	grid-template-rows: min-content minmax(0, 1fr);
 }
 
 .arcade-scrollable-panel-container{
@@ -73,17 +69,18 @@
 	margin: 3rem auto;
 }
 
-
-.arcade-central-panel {
+.arcade-central-panel{
+	height: 100%;
+	position: relative;
 	display: grid;
 	grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
 	grid-gap: 1rem;
-	position: relative;
 }
 
 
 .arcade-sidebar .saito-announcement {
 	margin-bottom: 1rem;
+	line-height: 1.25em;
 }
 
 
@@ -216,57 +213,47 @@
 
 
 .can-scroll-down::before {
-	content: " ";
+  font-family: FontAwesome;
+  content: "";
+  font-size: 4rem;
+  color: var(--border-color-general-dividers-dark);
 	position: absolute;
 	bottom: 0;
 	left: 0;
 	width: 100%;
-	height: 8rem;
+	text-align: center;
+  line-height: 10rem;
+	height: 10rem;
+	text-shadow: -3px -2px 2px var(--border-color-general-dividers), 0px 2px 2px var(--border-color-general-dividers), 3px -2px 2px var(--border-color-general-dividers);
 	z-index: 5;
 	pointer-events: none;
-    background: linear-gradient(180deg, transparent, var(--saito-background-color));
+    background: linear-gradient(180deg, transparent, var(--saito-background-color) 80%);
 } 
 
-.can-scroll-down:hover::after {
-  font-family: FontAwesome;
+.can-scroll-down:hover::before {
   content: "\f0d7";
-  position: absolute;
-  bottom: 0;
-  color: var(--border-color-general-dividers-dark);
-  font-size: 4rem;
-  z-index: 999;
-  text-align: center;
-  border-radius: var(--border-radius-arcade-game-list);
-  left: 50%;
-  transform: translateX(-50%);
-  line-height: 4rem;
 }
 
 /*  "\f0d8"  */
-.can-scroll-up::before {
-	content: " ";
+.can-scroll-up::after {
+  font-family: FontAwesome;
+  content: "";
+  font-size: 4rem;
+  color: var(--border-color-general-dividers-dark);
 	position: absolute;
-	top: calc(100% + 1rem);
+	top: 0;
 	left: 0;
 	width: 100%;
-	height: 8rem;
+	text-align: center;
+  line-height: 10rem;
+	height: 10rem;
+	text-shadow: -3px 2px 2px var(--border-color-general-dividers), 0px -2px 2px var(--border-color-general-dividers), 3px 2px 2px var(--border-color-general-dividers);
 	z-index: 5;
 	pointer-events: none;
-    background: linear-gradient(0deg, transparent, var(--saito-background-color));
+    background: linear-gradient(0deg, transparent, var(--saito-background-color) 80%);
 } 
 
 .can-scroll-up:hover::after {
-  font-family: FontAwesome;
   content: "\f0d8";
-  position: absolute;
-  color: var(--border-color-general-dividers-dark);
-  top: calc(100% + 1rem);
-  font-size: 4rem;
-  z-index: 999;
-  text-align: center;
-  border-radius: var(--border-radius-arcade-menu);
-  left: 50%;
-  transform: translateX(-50%);
-  line-height: 4rem;
 }
 

--- a/mods/arcade/web/css/arcade-game-slider.css
+++ b/mods/arcade/web/css/arcade-game-slider.css
@@ -16,8 +16,17 @@
 	--transition-delay: 0.5s;
 }
 
-.arcade-game-slider .game-slider .carousel .slider-button {
+.game-slider .carousel .slider-button {
 	display: none;
+}
+
+.saito-sidebar .game-slider{
+	border-radius: 0.5rem;
+	box-shadow: 0px 2px 4px var(--saito-bubble-shadow);
+}
+
+.carousel, .slides, .slide, .slide img {
+	border-radius: inherit;
 }
 
 .carousel {

--- a/mods/league/league.js
+++ b/mods/league/league.js
@@ -118,6 +118,14 @@ class League extends ModTemplate {
 			};
 		}
 
+		if (type == "leagues-for-arcade"){
+			this.styles = ['/league/style.css'];
+			this.attachStyleSheets();
+			return {
+				leagues: this.leagues,
+			};
+		}
+
 		return super.respondTo(type, obj);
 	}
 
@@ -248,14 +256,11 @@ class League extends ModTemplate {
 		if (qs == '.redsquare-sidebar') {
 			return true;
 		}
-		if (qs == '.arcade-leagues') {
-			return true;
-		}
 		return false;
 	}
 
 	renderInto(qs) {
-		if (qs == '.redsquare-sidebar' || qs == '.arcade-leagues') {
+		if (qs == '.redsquare-sidebar') {
 			if (!this.renderIntos[qs]) {
 				this.renderIntos[qs] = [];
 				this.renderIntos[qs].push(

--- a/mods/league/league.js
+++ b/mods/league/league.js
@@ -122,7 +122,9 @@ class League extends ModTemplate {
 			this.styles = ['/league/style.css'];
 			this.attachStyleSheets();
 			return {
-				leagues: this.leagues,
+				returnLeague: (league_id) => {
+					return this.returnLeague(league_id);
+				}
 			};
 		}
 

--- a/mods/midnight/midnight.js
+++ b/mods/midnight/midnight.js
@@ -22,6 +22,7 @@ class Midnight extends GameTemplate {
 		this.maxPlayers = 1;
 		this.minPlayers = 1;
 		this.app = app;
+		this.can_bet = 0;
 	}
 
 	/* Opt out of letting League create a default*/

--- a/mods/poker/poker.js
+++ b/mods/poker/poker.js
@@ -69,6 +69,8 @@ class Poker extends GameTableTemplate {
 
 		this.updateHTML = '';
 
+	    this.sort_priority = 1;
+
 	}
 
 	//

--- a/mods/settlers/settlers.js
+++ b/mods/settlers/settlers.js
@@ -218,6 +218,9 @@ class Settlers extends GameTemplate {
 		this.currently_active_player = 0;
 
 		this.enable_observer = false;
+
+	    this.sort_priority = 1;
+
 	}
 
 	async render(app) {

--- a/mods/twilight/src/twilight-start.js
+++ b/mods/twilight/src/twilight-start.js
@@ -83,6 +83,8 @@ class Twilight extends GameTemplate {
     this.region_key = { "asia": "Asia", "seasia": "Southeast Asia", "europe":"Europe", "africa":"Africa", "mideast":"Middle East", "camerica": "Central America", "samerica":"South America"};
     this.grace_window = 25;
 
+    this.sort_priority = 1;
+
   }
 
   showCardOverlay(cards, title = ""){

--- a/mods/twilight/twilight.js
+++ b/mods/twilight/twilight.js
@@ -83,6 +83,8 @@ class Twilight extends GameTemplate {
     this.region_key = { "asia": "Asia", "seasia": "Southeast Asia", "europe":"Europe", "africa":"Africa", "mideast":"Middle East", "camerica": "Central America", "samerica":"South America"};
     this.grace_window = 25;
 
+    this.sort_priority = 1;
+
   }
 
   showCardOverlay(cards, title = ""){

--- a/mods/wuziqi/wuziqi.js
+++ b/mods/wuziqi/wuziqi.js
@@ -17,7 +17,6 @@ class Wuziqi extends GameTemplate {
 		this.description =
 			'Take turns placing black or white tiles on a Go board of various sizes to make a line of five in a row to win the round. Also known as 五子棋, Gokomu, or Gobang.';
 		this.categories = 'Games Boardgame Classic';
-		//this.status = "Beta";
 
 		this.minPlayers = 2;
 		this.maxPlayers = 2;


### PR DESCRIPTION
This is the initial work for a new-ish Arcade that leans into the graphics
Key features: 

- drops left sidebar completely
- moves chat into right sidebar
- moves invites into right sidebar
- removes league rankings from right sidebar
- main content is a graphical list of games
- games will be sorted so that: the last game you played is displayed first and followed by most played games. Newcomers will have Settlers, Twilight, and Poker prioritized at the top of the list
- Layout is responsive and works well in mobile
- Additional text added to page to boost SEO and give newcomers something to read, since some people actually like that

To-do:
- Swap out all the arcade-game graphics
- Redesign the overlays (in conjunction with improving the game splash pages, they should be functionally equivalent)