### PR TITLE
Fix rogue font colors

### DIFF
--- a/web/saito/css-imports/themes/saito-arcade.theme.css
+++ b/web/saito/css-imports/themes/saito-arcade.theme.css
@@ -104,6 +104,7 @@ html[data-theme="arcade"] {
       --font-color-overlay-form-header: var(--font-color-primary);
       --font-color-overlay-form-text: var(--font-color-primary);
       --font-color-overlay-subform-recover: var(--font-color-primary);
+      --font-color-button-wallet-control: var(--saito-primary);
     /* BORDER THICKNESS */
       --border-thickness-button-primary: var(--border-thickness-thin);
       --border-thickness-button-hover-primary: var(--border-thickness-thin);

--- a/web/saito/css-imports/themes/saito-dark.theme.css
+++ b/web/saito/css-imports/themes/saito-dark.theme.css
@@ -68,6 +68,7 @@ html[data-theme="dark"] {
   --font-color-button-hover-modal-oldschool: var(--font-color-heavy);
   --font-color-hover-icons-left-sidebar: var(--font-color-heavy);
   --font-color-button-hover-wallet-control: var(--font-color-heavy);
+  --font-color-button-wallet-control: var(--saito-primary);
   --font-color-calendar-today: var(--font-color-primary);
   --font-color-calendar-hover: var(--font-color-primary);
 /* Menu and Header Font Colors */


### PR DESCRIPTION
Issue with font colors showing as "red" instead of primary theme colors:

![Screenshot from 2024-04-22 08-45-59](https://github.com/SaitoTech/saito-lite-rust/assets/104337801/057b4469-69ff-4f23-87ab-dbf79d543801)
![Screenshot from 2024-04-22 08-47-44](https://github.com/SaitoTech/saito-lite-rust/assets/104337801/e80a3831-4141-4680-b6a5-f565dfbc350d)
