### PR TITLE
Wallet backup & deposit changes

### DIFF
--- a/lib/saito/ui/saito-backup/saito-backup.js
+++ b/lib/saito/ui/saito-backup/saito-backup.js
@@ -24,8 +24,8 @@ class SaitoBackup {
 		}
 
 
-		this_self.app.options.wallet.backup_required_msg = 1;
-		await this_self.app.wallet.saveWallet();
+		this.app.options.wallet.backup_required_msg = 1;
+		await this.app.wallet.saveWallet();
 
 		this.attachEvents();
 	}

--- a/lib/saito/ui/saito-backup/saito-backup.js
+++ b/lib/saito/ui/saito-backup/saito-backup.js
@@ -9,21 +9,24 @@ class SaitoBackup {
 		this.overlay = new SaitoOverlay(this.app, this.mod);
 		this.msg = null;
 
-		this.app.connection.on('saito-backup-render-request', (obj) => {
+		this.app.connection.on('saito-backup-render-request', async (obj) => {
 			console.log('object: ', obj);
 			if (typeof obj.msg != 'undefined') {
 				this.msg = obj.msg;
 			}
-			this.render();
+			await this.render();
 		});
-
-		
 	}
-	render() {
+	async render() {
 		this.overlay.show(SaitoBackupTemplate(this.app, this.mod, this));
 		this.overlay.callback_on_close = () => {
 			this.callBackFunction();
 		}
+
+
+		this_self.app.options.wallet.backup_required_msg = 1;
+		await this_self.app.wallet.saveWallet();
+
 		this.attachEvents();
 	}
 
@@ -32,6 +35,7 @@ class SaitoBackup {
 		document.querySelector('#saito-backup-manual')
 		.addEventListener('click', async () => {
 			this_self.app.wallet.backupWallet();
+
 
 			this_self.app.options.wallet.backup_required_msg = 0;
 			await this_self.app.wallet.saveWallet();
@@ -42,11 +46,14 @@ class SaitoBackup {
 		document.querySelector('#saito-backup-auto')
 		.addEventListener('click', async () => {
 			
+
 			this_self.app.options.wallet.backup_required_msg = 0;
 			await this_self.app.wallet.saveWallet();
 
+
 			this_self.app.connection.emit(
-				'recovery-backup-overlay-render-request'
+				'recovery-backup-overlay-render-request',
+				{}
 			);
 			this_self.overlay.hide();
 		});

--- a/lib/saito/ui/saito-header/saito-header.js
+++ b/lib/saito/ui/saito-header/saito-header.js
@@ -137,7 +137,7 @@ class SaitoHeader extends UIModTemplate {
 			console.log('update 3 ////');
 			this.updateHeaderMessage(msg, flash, callback);
 		});
-		
+
 	}
 
 	async initialize(app) {
@@ -262,6 +262,26 @@ class SaitoHeader extends UIModTemplate {
 		this.renderUsername();
 		this.attachEvents();
 		await this.initiatePendingDepositsCheck();
+
+		if (typeof app.options.wallet.backup_required_msg) {
+			let backup_required_msg = app.options.wallet.backup_required_msg;
+
+			if (backup_required_msg == 1) {
+				this.app.connection.emit(
+					'saito-header-update-message',
+					{
+						msg: 'Wallet backup required',
+						flash: true,
+						callback: function() {
+							this_header.app.connection.emit(
+								'recovery-backup-overlay-render-request'
+							);
+						}
+					}
+				);
+			}
+		}
+
 	}
 
 	addFloatingMenu() {
@@ -666,10 +686,8 @@ class SaitoHeader extends UIModTemplate {
 			document.getElementById('saito-header').style.zIndex = 20;
 			this.is_open = true;
 
-			let preferred_crypto =
-				await this.app.wallet.returnPreferredCrypto();
-			await preferred_crypto.returnBalance();
-
+			
+			await this.checkBalanceUpdate();
 			await this.initiateBalanceCheck();
 		}
 	}
@@ -711,54 +729,68 @@ class SaitoHeader extends UIModTemplate {
 
 	async initiatePendingDepositsCheck() {
 		let this_self = this;
-	
-			this_self.deposit_check_interval = setInterval(async function () {
-				let preferred_crypto = await this_self.app.wallet.returnPreferredCrypto();
-				await preferred_crypto.fetchPendingDeposits(function(res){
-					//console.log('pending deposit in saito-header: ', res); 
+		let preferred_crypto = await this_self.app.wallet.returnPreferredCrypto();
+		let confirmations = 0;
+		let network_info = await preferred_crypto.returnNetworkInfo(preferred_crypto.asset_id);
+		if (typeof network_info.confirmations != 'undefined') {
+			confirmations = network_info.confirmations;
+		}
 
+		this_self.deposit_check_interval = setInterval(async function () {
+			await preferred_crypto.fetchPendingDeposits(function(res){
+				//console.log('pending deposit in saito-header: ', res); 
+				if (res.length > 0) {
+					let pending_transfer = res[res.length - 1];
 
-					if (res.length > 0) {
+					console.log('pending_transfer: ', pending_transfer); 
 
-						let pending_transfer = res[res.length - 1];
+					let amount = Number(pending_transfer.amount);
 
-						console.log('pending_transfer: ', pending_transfer); 
+					console.log(`${amount} ${preferred_crypto.ticker} deposit pending 
+						(${pending_transfer.confirmations}/${confirmations} confrimations)`);
 
-						let amount = Number(pending_transfer.amount);
+					if (amount > 0) {
+						// pending transfer is deposit
 
-						console.log(`${amount} ${preferred_crypto.ticker} deposit processing...`);
+							if (pending_transfer.confirmations < confirmations) {
+								this_self.updateHeaderMessage(
+									`${amount} ${preferred_crypto.ticker} deposit pending 
+									(${pending_transfer.confirmations}/${confirmations} confrimations)`,
+									true,
+									function(){
+										this_self.app.connection.emit('saito-crypto-history-render-request', {});
+									}
+								);
 
-						if (amount > 0) {
-							// pending transfer is deposit
-
-							console.log('update 1 ////');
-							this_self.updateHeaderMessage(
-								`${amount} ${preferred_crypto.ticker} deposit processing...`,
-								true
-							);
-
-							if (this_self.show_msg) {
-								siteMessage(`New ${preferred_crypto.ticker} deposit`, 10000);
-								this_self.show_msg = false;
+								if (this_self.show_msg) {
+									siteMessage(`New ${preferred_crypto.ticker} deposit`, 10000);
+									this_self.show_msg = false;
+								}
+							} else {
+								if (this_self.can_update_header_msg) {
+									this_self.updateHeaderMessage();
+									this_self.show_msg = true;
+								}
 							}
-						} else {
-							// pending transfer is withdrawl
+
+					} else {
+						// pending transfer is withdrawl
+						this_self.show_msg = true;
+					}
+					
+				} else {
+					//	console.log('app: ', this_self.app);
+						//console.log('backup value: ', this_self.app.options.wallet.backup_required);
+						// render username, with no params here
+
+						//console.log('update 2 ////');
+						if (this_self.can_update_header_msg) {
+							this_self.updateHeaderMessage();
 							this_self.show_msg = true;
 						}
-						
-					} else {
-						//	console.log('app: ', this_self.app);
-							//console.log('backup value: ', this_self.app.options.wallet.backup_required);
-							// render username, with no params here
-
-							//console.log('update 2 ////');
-							if (this_self.can_update_header_msg) {
-								this_self.updateHeaderMessage();
-								this_self.show_msg = true;
-							}
-					}
-				});
-			}, 10000);
+				}
+			});
+		}, 10000);
 		
 	}
 
@@ -881,6 +913,35 @@ class SaitoHeader extends UIModTemplate {
 			}, 10000);
 		}
 	}
+
+
+	async checkBalanceUpdate(){
+		try {
+			let preferred_crypto = await this.app.wallet.returnPreferredCrypto();
+			let previous_balance = 0;
+
+			if ("crypto" in this.app.options) {
+				if (preferred_crypto.ticker in this.app.options.crypto)
+					previous_balance = Number(this.app.options.crypto[preferred_crypto.ticker].balance);
+			}
+
+			await preferred_crypto.returnBalance();
+
+			if ("crypto" in this.app.options) {
+				if (preferred_crypto.ticker in this.app.options.crypto) {
+					let current_balance = Number(this.app.options.crypto[preferred_crypto.ticker].balance);
+					console.log('current_balance > previous_balance: ', current_balance , previous_balance);
+
+					if (current_balance > previous_balance){
+						siteMessage(`New ${(current_balance - previous_balance).toFixed(2)} ${preferred_crypto.ticker} deposit`, 5000);
+					}
+				}
+			}
+		} catch(err) {
+			console.warn("Error in checkBalanceUpdate: ", err);
+		}
+	}
+
 }
 
 module.exports = SaitoHeader;

--- a/lib/saito/wallet.ts
+++ b/lib/saito/wallet.ts
@@ -416,7 +416,7 @@ export default class Wallet extends SaitoWallet {
 			this.app.options.wallet = {};
 		}
 		this.app.options.wallet.backup_required = 0;
-		this.app.options.wallet.backup_required_msg = 1;
+		this.app.options.wallet.backup_required_msg = 0;
 
 
 		await this.saveWallet();

--- a/lib/templates/cryptomodule.js
+++ b/lib/templates/cryptomodule.js
@@ -507,4 +507,8 @@ CryptoModule.prototype.validateAddress = async function(address, ticker) { retur
  */
 CryptoModule.prototype.returnUtxo = async function(state = 'unspent', limit = 1000, order = 'DESC') { return true; }
 
+
+CryptoModule.prototype.returnNetworkInfo = async function(ticker) { return {} }
+
+
 module.exports = CryptoModule;

--- a/mods/encrypt/encrypt.js
+++ b/mods/encrypt/encrypt.js
@@ -379,6 +379,14 @@ class Encrypt extends ModTemplate {
     }
 
     siteMessage(`Successfully added ${this.app.keychain.returnUsername(sender, 8)} as a friend`, 5000);
+
+    let msg = `Your wallet has added new crypto keys. 
+            Unless you backup your wallet, you may lose these keys. 
+            Do you want help backing up your wallet?`;
+    this.app.connection.emit(
+      'saito-backup-render-request',
+      {msg: msg}
+    );
  
     let alice_publicKey = Buffer.from(senderkeydata.aes_publicKey, "hex");
     let alice_privatekey = Buffer.from(senderkeydata.aes_privatekey, "hex");

--- a/mods/mixin/lib/mixinmodule.js
+++ b/mods/mixin/lib/mixinmodule.js
@@ -433,8 +433,8 @@ class MixinModule extends CryptoModule {
 	}
 
 
-	returnNetworkFee(asset_id) {
-		return this.mixin.checkNetworkFee(asset_id);
+	returnNetworkInfo() {
+		return this.mixin.returnNetworkInfo(this.asset_id);
 	}
 
 

--- a/mods/mixin/mixin.js
+++ b/mods/mixin/mixin.js
@@ -471,7 +471,7 @@ class Mixin extends ModTemplate {
   }
 
 
-  async checkNetworkFee(asset_id){
+  async returnNetworkInfo(asset_id){
     try {
       let user = MixinApi({
         keystore: {
@@ -483,12 +483,7 @@ class Mixin extends ModTemplate {
       });
 
       let asset = await user.network.fetchAsset(asset_id);
-      if (typeof asset.fee != 'undefined') {
-        return asset.fee;  
-      } else {
-        return 0;
-      }
-      
+      return asset;
     } catch(err) {
       console.error("ERROR: Mixin error check network fee: " + err);
       return false;
@@ -1007,7 +1002,7 @@ class Mixin extends ModTemplate {
 
 
   async fetchPendingDeposits(asset_id, destination, callback){
-    //try {
+    try {
       let user = MixinApi({
         keystore: {
           app_id: this.mixin.user_id,
@@ -1023,14 +1018,11 @@ class Mixin extends ModTemplate {
       };
 
       let deposits = await user.safe.pendingDeposits(params);
-    
-
-      console.log('deposits in mixin: ', deposits);
       return callback(deposits);
-    // } catch(err) {
-    //   console.error("ERROR: Mixin error fetch fetchPendingDeposits: " + err);
-    //   return false;
-    // }
+    } catch(err) {
+      console.error("ERROR: Mixin error fetch fetchPendingDeposits: " + err);
+      return false;
+    }
   }
 
 

--- a/mods/recovery/lib/backup.template.js
+++ b/mods/recovery/lib/backup.template.js
@@ -39,7 +39,7 @@ module.exports = BackupTemplate = (identifier, newIdentifier) => {
       		<div class="saito-overlay-form-checkbox-container">	
 	      		<input type="checkbox" class="saito-overlay-subform-checkbox" checked />
 	      		<div class="saito-overlay-subform-text">
-	      			Please save an encrypted copy on-chain, 
+	      			Save an encrypted copy on-chain, 
 	      			so I can recover my account quickly and easily on any device
 	      		</div>
       		</div>

--- a/mods/recovery/recovery.js
+++ b/mods/recovery/recovery.js
@@ -61,12 +61,17 @@ class Recovery extends ModTemplate {
 				//
 				//If we already have the email/password, just send the backup
 				//
+
 				let key = app.keychain.returnKey(this.publicKey);
 				if (key) {
 					if (
 						key.wallet_decryption_secret &&
 						key.wallet_retrieval_hash
 					) {
+						this.app.options.wallet.backup_required_msg = 0;
+						await this.app.wallet.saveWallet();
+
+						app.connection.emit('recovery-backup-loader-overlay-render-request', {});
 						let newtx = await this.createBackupTransaction(
 							key.wallet_decryption_secret,
 							key.wallet_retrieval_hash
@@ -293,6 +298,11 @@ class Recovery extends ModTemplate {
 	async backupWallet(email, password) {
 		let decryption_secret = this.returnDecryptionSecret(email, password);
 		let retrieval_hash = this.returnRetrievalHash(email, password);
+
+		if (typeof this.app.options.wallet != 'undefined') {
+			this.app.options.wallet.account_recovery_secret = decryption_secret;
+			this.app.options.wallet.account_recovery_hash = retrieval_hash;
+		}
 
 		//
 		// save email


### PR DESCRIPTION
-  Show backup overlay when adding new contact (new keypair to wallet).

-  Save recovery hash & secret to wallet on backup.

-  Re-use recovery hash & secret when doing backup for second time instead of asking for email/pass.

-  Add confirmation count in pending deposit message.

-  Notify user of new deposit for saito to saito wallet (trx) deposit when hamburger menu is opened.